### PR TITLE
fix: correct background hex code in Tailwind config

### DIFF
--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -6,7 +6,7 @@ export default {
       colors: {
         primary: "#FF6F00",  // Orange (buttons & accents)
         secondary: "#FFB74D", // Light orange (background)
-        background: "#ffff", 
+        background: "#ffffff",
         textDark: "#212121", // Dark text
         textLight: "#757575", // Light gray text
         borderColor: "#E0E0E0", // Border color


### PR DESCRIPTION
## Summary
- use full six-digit white hex code for background color

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: adminGuard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d42fc2e48333a615f02cce708f4e