### PR TITLE
fix: accept JSON body for cart item updates

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/CartController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/CartController.java
@@ -39,7 +39,8 @@ public class CartController {
     // Update cart item quantity
     @PutMapping("/update/{cartItemId}")
     public ResponseEntity<CartItemDTO> updateCartItem(@PathVariable Long cartItemId,
-                                                      @RequestParam Integer quantity) {
+                                                      @RequestBody Map<String, Object> payload) {
+        Integer quantity = Integer.valueOf(payload.get("quantity").toString());
         CartItemDTO updatedCartItemDTO = cartService.updateCartItem(cartItemId, quantity);
         return ResponseEntity.ok(updatedCartItemDTO);
     }


### PR DESCRIPTION
## Summary
- handle cart item quantity updates via JSON payload instead of query parameter

## Testing
- `./mvnw -q test` (failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)
- `npm test` (failed: export 'adminGuard' was not found in './admin.guard')

------
https://chatgpt.com/codex/tasks/task_e_6898d17eb41c833386f490db916424a4