### PR TITLE
test: add auth interceptor header tests

### DIFF
--- a/Frontend/src/app/authInterceptor/auth.interceptor.spec.ts
+++ b/Frontend/src/app/authInterceptor/auth.interceptor.spec.ts
@@ -1,16 +1,58 @@
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { AuthInterceptor } from './auth.interceptor';
 
 describe('AuthInterceptor', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    providers: [
-      AuthInterceptor
-      ]
-  }));
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: AuthInterceptor,
+          multi: true,
+        },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    localStorage.removeItem('token');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.removeItem('token');
+  });
 
   it('should be created', () => {
     const interceptor: AuthInterceptor = TestBed.inject(AuthInterceptor);
     expect(interceptor).toBeTruthy();
+  });
+
+  it('adds Authorization header for internal requests when token exists', () => {
+    localStorage.setItem('token', 'abc');
+
+    http.get('/api/data').subscribe();
+
+    const req = httpMock.expectOne('/api/data');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer abc');
+    req.flush({});
+  });
+
+  it('does not modify external requests', () => {
+    localStorage.setItem('token', 'abc');
+
+    const url = 'https://openrouteservice.org/test';
+    http.get(url).subscribe();
+
+    const req = httpMock.expectOne(url);
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
   });
 });


### PR DESCRIPTION
## Summary
- verify AuthInterceptor adds Authorization header when token is present
- ensure requests to external domains are left untouched

## Testing
- `npm test -- --watch=false --include=src/app/authInterceptor/auth.interceptor.spec.ts` *(fails: Error: src/app/guards/admin.guard.spec.ts:4:10 - error TS2724: '"./admin.guard"' has no exported member named 'adminGuard'. Did you mean 'AdminGuard'?)*


------
https://chatgpt.com/codex/tasks/task_e_6898d4342ab08333b8e6fbe92914dd67