### PR TITLE
feat: add admin driver management

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/AdminDriverController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/AdminDriverController.java
@@ -1,0 +1,39 @@
+package com.example.backend.controller;
+
+import com.example.backend.auth.RegisterRequest;
+import com.example.backend.service.AdminDriverService;
+import com.example.backend.user.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin/drivers")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminDriverController {
+
+    private final AdminDriverService adminDriverService;
+
+    @PostMapping
+    public ResponseEntity<User> createDriver(@Valid @RequestBody RegisterRequest request) {
+        return ResponseEntity.ok(adminDriverService.createDriver(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<User>> getAllDrivers() {
+        return ResponseEntity.ok(adminDriverService.getAllDrivers());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteDriver(@PathVariable Long id) {
+        adminDriverService.deleteDriver(id);
+        return ResponseEntity.ok(Map.of("message", "Driver deleted"));
+    }
+}
+

--- a/Backend/backend/src/main/java/com/example/backend/repository/UserRepository.java
+++ b/Backend/backend/src/main/java/com/example/backend/repository/UserRepository.java
@@ -14,4 +14,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     List<User> findByRoleAndDriverStatus(Role role, DriverStatus driverStatus);
+    List<User> findByRole(Role role);
 }

--- a/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
@@ -1,0 +1,48 @@
+package com.example.backend.service;
+
+import com.example.backend.auth.RegisterRequest;
+import com.example.backend.repository.UserRepository;
+import com.example.backend.user.DriverStatus;
+import com.example.backend.user.Role;
+import com.example.backend.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDriverService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User createDriver(RegisterRequest request) {
+        userRepository.findByEmail(request.getEmail())
+                .ifPresent(u -> {
+                    throw new IllegalArgumentException("Email already exists");
+                });
+
+        User driver = User.builder()
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(Role.DRIVER)
+                .driverStatus(DriverStatus.AVAILABLE)
+                .build();
+
+        return userRepository.save(driver);
+    }
+
+    public List<User> getAllDrivers() {
+        return userRepository.findByRole(Role.DRIVER);
+    }
+
+    public void deleteDriver(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new RuntimeException("Driver not found");
+        }
+        userRepository.deleteById(id);
+    }
+}
+

--- a/Backend/backend/src/test/java/com/example/backend/controller/AdminDriverControllerTest.java
+++ b/Backend/backend/src/test/java/com/example/backend/controller/AdminDriverControllerTest.java
@@ -1,0 +1,66 @@
+package com.example.backend.controller;
+
+import com.example.backend.auth.RegisterRequest;
+import com.example.backend.service.AdminDriverService;
+import com.example.backend.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminDriverController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AdminDriverControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminDriverService adminDriverService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createDriverReturnsCreatedDriver() throws Exception {
+        User driver = User.builder().id(1L).email("driver@example.com").build();
+        when(adminDriverService.createDriver(any(RegisterRequest.class))).thenReturn(driver);
+
+        mockMvc.perform(post("/api/admin/drivers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"driver@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("driver@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getAllDriversReturnsList() throws Exception {
+        List<User> drivers = List.of(User.builder().id(1L).email("a@b.com").build());
+        when(adminDriverService.getAllDrivers()).thenReturn(drivers);
+
+        mockMvc.perform(get("/api/admin/drivers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].email").value("a@b.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteDriverCallsService() throws Exception {
+        mockMvc.perform(delete("/api/admin/drivers/1"))
+                .andExpect(status().isOk());
+
+        verify(adminDriverService).deleteDriver(1L);
+    }
+}
+

--- a/Backend/backend/src/test/java/com/example/backend/service/AdminDriverServiceTest.java
+++ b/Backend/backend/src/test/java/com/example/backend/service/AdminDriverServiceTest.java
@@ -1,0 +1,94 @@
+package com.example.backend.service;
+
+import com.example.backend.auth.RegisterRequest;
+import com.example.backend.repository.UserRepository;
+import com.example.backend.user.DriverStatus;
+import com.example.backend.user.Role;
+import com.example.backend.user.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDriverServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AdminDriverService adminDriverService;
+
+    @Test
+    void createDriverStoresEncodedPasswordAndRole() {
+        RegisterRequest request = mock(RegisterRequest.class);
+        when(request.getEmail()).thenReturn("driver@example.com");
+        when(request.getPassword()).thenReturn("secret");
+        when(userRepository.findByEmail("driver@example.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("secret")).thenReturn("encoded");
+
+        User saved = User.builder()
+                .id(1L)
+                .email("driver@example.com")
+                .password("encoded")
+                .role(Role.DRIVER)
+                .driverStatus(DriverStatus.AVAILABLE)
+                .build();
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+
+        User result = adminDriverService.createDriver(request);
+
+        assertEquals(Role.DRIVER, result.getRole());
+        assertEquals(DriverStatus.AVAILABLE, result.getDriverStatus());
+        assertEquals("encoded", result.getPassword());
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertEquals("driver@example.com", captor.getValue().getEmail());
+    }
+
+    @Test
+    void createDriverThrowsWhenEmailExists() {
+        RegisterRequest request = mock(RegisterRequest.class);
+        when(request.getEmail()).thenReturn("driver@example.com");
+        when(userRepository.findByEmail("driver@example.com")).thenReturn(Optional.of(new User()));
+
+        assertThrows(IllegalArgumentException.class, () -> adminDriverService.createDriver(request));
+    }
+
+    @Test
+    void getAllDriversReturnsList() {
+        List<User> drivers = List.of(new User());
+        when(userRepository.findByRole(Role.DRIVER)).thenReturn(drivers);
+
+        assertEquals(drivers, adminDriverService.getAllDrivers());
+    }
+
+    @Test
+    void deleteDriverRemovesExistingDriver() {
+        when(userRepository.existsById(1L)).thenReturn(true);
+
+        adminDriverService.deleteDriver(1L);
+
+        verify(userRepository).deleteById(1L);
+    }
+
+    @Test
+    void deleteDriverThrowsWhenNotFound() {
+        when(userRepository.existsById(1L)).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> adminDriverService.deleteDriver(1L));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add repository method for querying users by role
- implement service/controller for admin driver creation, listing, and deletion
- cover service and controller with unit tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d763c3d4833384d4959529242f2a