### PR TITLE
Use DTO for driver management and sync admin UI

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/AdminDriverController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/AdminDriverController.java
@@ -1,8 +1,8 @@
 package com.example.backend.controller;
 
 import com.example.backend.auth.RegisterRequest;
+import com.example.backend.entity.DriverDTO;
 import com.example.backend.service.AdminDriverService;
-import com.example.backend.user.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,12 +21,12 @@ public class AdminDriverController {
     private final AdminDriverService adminDriverService;
 
     @PostMapping
-    public ResponseEntity<User> createDriver(@Valid @RequestBody RegisterRequest request) {
+    public ResponseEntity<DriverDTO> createDriver(@Valid @RequestBody RegisterRequest request) {
         return ResponseEntity.ok(adminDriverService.createDriver(request));
     }
 
     @GetMapping
-    public ResponseEntity<List<User>> getAllDrivers() {
+    public ResponseEntity<List<DriverDTO>> getAllDrivers() {
         return ResponseEntity.ok(adminDriverService.getAllDrivers());
     }
 

--- a/Backend/backend/src/main/java/com/example/backend/entity/DriverDTO.java
+++ b/Backend/backend/src/main/java/com/example/backend/entity/DriverDTO.java
@@ -1,0 +1,13 @@
+package com.example.backend.entity;
+
+import com.example.backend.user.DriverStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DriverDTO {
+    private Long id;
+    private String email;
+    private DriverStatus driverStatus;
+}

--- a/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
@@ -1,6 +1,7 @@
 package com.example.backend.service;
 
 import com.example.backend.auth.RegisterRequest;
+import com.example.backend.entity.DriverDTO;
 import com.example.backend.repository.UserRepository;
 import com.example.backend.user.DriverStatus;
 import com.example.backend.user.Role;
@@ -18,7 +19,7 @@ public class AdminDriverService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public User createDriver(RegisterRequest request) {
+    public DriverDTO createDriver(RegisterRequest request) {
         userRepository.findByEmail(request.getEmail())
                 .ifPresent(u -> {
                     throw new IllegalArgumentException("Email already exists");
@@ -31,11 +32,14 @@ public class AdminDriverService {
                 .driverStatus(DriverStatus.AVAILABLE)
                 .build();
 
-        return userRepository.save(driver);
+        User saved = userRepository.save(driver);
+        return new DriverDTO(saved.getId(), saved.getEmail(), saved.getDriverStatus());
     }
 
-    public List<User> getAllDrivers() {
-        return userRepository.findByRole(Role.DRIVER);
+    public List<DriverDTO> getAllDrivers() {
+        return userRepository.findByRole(Role.DRIVER).stream()
+                .map(u -> new DriverDTO(u.getId(), u.getEmail(), u.getDriverStatus()))
+                .toList();
     }
 
     public void deleteDriver(Long id) {

--- a/Frontend/src/app/admin/admin-drivers/admin-drivers.component.html
+++ b/Frontend/src/app/admin/admin-drivers/admin-drivers.component.html
@@ -6,8 +6,7 @@
   <form (ngSubmit)="addDriver()" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
     <input type="email" [(ngModel)]="newDriver.email" name="email" placeholder="Email" class="form-input" required />
     <input type="password" [(ngModel)]="newDriver.password" name="password" placeholder="Password" class="form-input" required />
-    <input type="text" [(ngModel)]="newDriver.status" name="status" placeholder="Status (optional)" class="form-input" />
-    <button type="submit" class="bg-green-600 text-white py-2 px-4 rounded md:col-span-3 hover:bg-green-700">
+    <button type="submit" class="bg-green-600 text-white py-2 px-4 rounded md:col-span-2 hover:bg-green-700">
       Add Driver
     </button>
   </form>
@@ -23,7 +22,7 @@
     <tbody>
       <tr *ngFor="let driver of drivers" class="border-t">
         <td class="p-2">{{ driver.email }}</td>
-        <td class="p-2">{{ driver.status }}</td>
+        <td class="p-2">{{ driver.driverStatus }}</td>
         <td class="p-2">
           <button (click)="deleteDriver(driver.id)" class="text-red-600 hover:underline">Delete</button>
         </td>

--- a/Frontend/src/app/admin/admin-drivers/admin-drivers.component.spec.ts
+++ b/Frontend/src/app/admin/admin-drivers/admin-drivers.component.spec.ts
@@ -31,7 +31,7 @@ describe('AdminDriversComponent', () => {
   });
 
   it('should call createDriver on addDriver', () => {
-    component.newDriver = { email: 'test@example.com', password: '123456', status: '' };
+    component.newDriver = { email: 'test@example.com', password: '123456' };
     component.addDriver();
     expect(adminServiceSpy.createDriver).toHaveBeenCalledWith(component.newDriver);
   });

--- a/Frontend/src/app/admin/admin-drivers/admin-drivers.component.ts
+++ b/Frontend/src/app/admin/admin-drivers/admin-drivers.component.ts
@@ -8,7 +8,7 @@ import { AdminService } from 'src/app/services/admin.service';
 })
 export class AdminDriversComponent implements OnInit {
   drivers: any[] = [];
-  newDriver = { email: '', password: '', status: '' };
+  newDriver = { email: '', password: '' };
 
   constructor(private adminService: AdminService) {}
 
@@ -30,7 +30,7 @@ export class AdminDriversComponent implements OnInit {
 
     this.adminService.createDriver(this.newDriver).subscribe({
       next: () => {
-        this.newDriver = { email: '', password: '', status: '' };
+        this.newDriver = { email: '', password: '' };
         this.loadDrivers();
       },
       error: err => console.error('Failed to create driver', err)

--- a/Frontend/src/app/guards/admin.guard.spec.ts
+++ b/Frontend/src/app/guards/admin.guard.spec.ts
@@ -1,17 +1,26 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { Router } from '@angular/router';
+import { AdminGuard } from './admin.guard';
+import { AuthService } from '../services/auth.service';
 
-import { adminGuard } from './admin.guard';
-
-describe('adminGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => adminGuard(...guardParameters));
+describe('AdminGuard', () => {
+  let guard: AdminGuard;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['getUserRole']);
+    TestBed.configureTestingModule({
+      providers: [
+        AdminGuard,
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    });
+    guard = TestBed.inject(AdminGuard);
   });
 
   it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+    expect(guard).toBeTruthy();
   });
 });

--- a/Frontend/src/app/guards/driver.guard.spec.ts
+++ b/Frontend/src/app/guards/driver.guard.spec.ts
@@ -1,17 +1,26 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { Router } from '@angular/router';
+import { DriverGuard } from './driver.guard';
+import { AuthService } from '../services/auth.service';
 
-import { driverGuard } from './driver.guard';
-
-describe('driverGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => driverGuard(...guardParameters));
+describe('DriverGuard', () => {
+  let guard: DriverGuard;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['getUserRole']);
+    TestBed.configureTestingModule({
+      providers: [
+        DriverGuard,
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    });
+    guard = TestBed.inject(DriverGuard);
   });
 
   it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+    expect(guard).toBeTruthy();
   });
 });

--- a/Frontend/src/app/guards/user.guard.spec.ts
+++ b/Frontend/src/app/guards/user.guard.spec.ts
@@ -1,17 +1,26 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { Router } from '@angular/router';
+import { UserGuard } from './user.guard';
+import { AuthService } from '../services/auth.service';
 
-import { userGuard } from './user.guard';
-
-describe('userGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => userGuard(...guardParameters));
+describe('UserGuard', () => {
+  let guard: UserGuard;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['getUserRole']);
+    TestBed.configureTestingModule({
+      providers: [
+        UserGuard,
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    });
+    guard = TestBed.inject(UserGuard);
   });
 
   it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+    expect(guard).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- expose a lightweight `DriverDTO` instead of full `User` entities
- refactor admin driver service/controller to return the new DTO
- align Angular driver management UI with `driverStatus` data and drop unused status field

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6898dea495188333a7991b2bef5090fd