### PR TITLE
test: update driver tests to use DriverDTO

### DIFF
--- a/Backend/backend/src/test/java/com/example/backend/controller/AdminDriverControllerTest.java
+++ b/Backend/backend/src/test/java/com/example/backend/controller/AdminDriverControllerTest.java
@@ -1,8 +1,9 @@
 package com.example.backend.controller;
 
 import com.example.backend.auth.RegisterRequest;
+import com.example.backend.entity.DriverDTO;
 import com.example.backend.service.AdminDriverService;
-import com.example.backend.user.User;
+import com.example.backend.user.DriverStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,7 +34,7 @@ class AdminDriverControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void createDriverReturnsCreatedDriver() throws Exception {
-        User driver = User.builder().id(1L).email("driver@example.com").build();
+        DriverDTO driver = new DriverDTO(1L, "driver@example.com", DriverStatus.AVAILABLE);
         when(adminDriverService.createDriver(any(RegisterRequest.class))).thenReturn(driver);
 
         mockMvc.perform(post("/api/admin/drivers")
@@ -46,7 +47,7 @@ class AdminDriverControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void getAllDriversReturnsList() throws Exception {
-        List<User> drivers = List.of(User.builder().id(1L).email("a@b.com").build());
+        List<DriverDTO> drivers = List.of(new DriverDTO(1L, "a@b.com", DriverStatus.AVAILABLE));
         when(adminDriverService.getAllDrivers()).thenReturn(drivers);
 
         mockMvc.perform(get("/api/admin/drivers"))

--- a/Backend/backend/src/test/java/com/example/backend/service/AdminDriverServiceTest.java
+++ b/Backend/backend/src/test/java/com/example/backend/service/AdminDriverServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.backend.service;
 
 import com.example.backend.auth.RegisterRequest;
+import com.example.backend.entity.DriverDTO;
 import com.example.backend.repository.UserRepository;
 import com.example.backend.user.DriverStatus;
 import com.example.backend.user.Role;
@@ -47,15 +48,18 @@ class AdminDriverServiceTest {
                 .build();
         when(userRepository.save(any(User.class))).thenReturn(saved);
 
-        User result = adminDriverService.createDriver(request);
+        DriverDTO result = adminDriverService.createDriver(request);
 
-        assertEquals(Role.DRIVER, result.getRole());
+        assertEquals("driver@example.com", result.getEmail());
         assertEquals(DriverStatus.AVAILABLE, result.getDriverStatus());
-        assertEquals("encoded", result.getPassword());
 
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(captor.capture());
-        assertEquals("driver@example.com", captor.getValue().getEmail());
+        User captured = captor.getValue();
+        assertEquals(Role.DRIVER, captured.getRole());
+        assertEquals(DriverStatus.AVAILABLE, captured.getDriverStatus());
+        assertEquals("encoded", captured.getPassword());
+        assertEquals("driver@example.com", captured.getEmail());
     }
 
     @Test
@@ -69,10 +73,14 @@ class AdminDriverServiceTest {
 
     @Test
     void getAllDriversReturnsList() {
-        List<User> drivers = List.of(new User());
+        List<User> drivers = List.of(User.builder().id(1L).email("a@b.com").driverStatus(DriverStatus.AVAILABLE).build());
         when(userRepository.findByRole(Role.DRIVER)).thenReturn(drivers);
 
-        assertEquals(drivers, adminDriverService.getAllDrivers());
+        List<DriverDTO> result = adminDriverService.getAllDrivers();
+
+        assertEquals(1, result.size());
+        assertEquals("a@b.com", result.get(0).getEmail());
+        assertEquals(DriverStatus.AVAILABLE, result.get(0).getDriverStatus());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update admin driver controller tests to mock DriverDTO responses
- adjust service tests to assert DriverDTO values and verify saved user

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898e3ae89f08333bb1585a1324ae131