### PR TITLE
Handle duplicate driver email with custom exception

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/config/GlobalExceptionHandler.java
+++ b/Backend/backend/src/main/java/com/example/backend/config/GlobalExceptionHandler.java
@@ -26,6 +26,13 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.CONFLICT.value(), ex.getMessage()));
     }
 
+    // Handle IllegalArgumentException
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
+    }
+
     // Handle validation exceptions
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {

--- a/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
@@ -6,6 +6,7 @@ import com.example.backend.repository.UserRepository;
 import com.example.backend.user.DriverStatus;
 import com.example.backend.user.Role;
 import com.example.backend.user.User;
+import com.example.backend.config.EmailAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ public class AdminDriverService {
     public DriverDTO createDriver(RegisterRequest request) {
         userRepository.findByEmail(request.getEmail())
                 .ifPresent(u -> {
-                    throw new IllegalArgumentException("Email already exists");
+                    throw new EmailAlreadyExistsException("Email already exists");
                 });
 
         User driver = User.builder()


### PR DESCRIPTION
## Summary
- Replace generic IllegalArgumentException with EmailAlreadyExistsException in AdminDriverService
- Add global handler for IllegalArgumentException returning HTTP 400

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898e392cbe483338ae819c7418f2d08