### PR TITLE
Provide global shim for webpack

### DIFF
--- a/Frontend/global.js
+++ b/Frontend/global.js
@@ -1,0 +1,1 @@
+module.exports = globalThis;

--- a/Frontend/webpack.config.js
+++ b/Frontend/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   plugins: [
     new webpack.ProvidePlugin({
       process: 'process/browser',
-      Buffer: ['buffer', 'Buffer']
+      Buffer: ['buffer', 'Buffer'],
+      global: require.resolve('./global.js')
     }),
   ],
 };


### PR DESCRIPTION
## Summary
- map `global` to a local shim exporting `globalThis` via webpack's `ProvidePlugin`
- add small `global.js` shim file

## Testing
- `npm run build -- --configuration development`

------
https://chatgpt.com/codex/tasks/task_e_6898f504b8b4833382fe6723f8c5b0a2