### PR TITLE
feat: load polyfills before bootstrap

### DIFF
--- a/Frontend/src/main.ts
+++ b/Frontend/src/main.ts
@@ -1,7 +1,6 @@
+import './polyfills';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { AppModule } from './app/app.module';
-
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));

--- a/Frontend/tsconfig.app.json
+++ b/Frontend/tsconfig.app.json
@@ -9,8 +9,7 @@
     }
   },
   "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
+    "src/main.ts"
   ],
   "include": [
     "src/**/*.d.ts"


### PR DESCRIPTION
## Summary
- ensure Angular polyfills are loaded before bootstrap
- remove polyfills file from TypeScript config to avoid unused warning

## Testing
- `ng serve`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899093465288333be11fecd2e36c28f