### PR TITLE
Allow SockJS endpoint without auth

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/config/SecurityConfiguration.java
+++ b/Backend/backend/src/main/java/com/example/backend/config/SecurityConfiguration.java
@@ -46,6 +46,9 @@ public class SecurityConfiguration {
                                 "/uploads/**"         // ✅ Just in case direct file path is hit
                         ).permitAll()
 
+                        // ✅ Allow WebSocket (SockJS) connections
+                        .requestMatchers("/ws/**").permitAll()
+
                         // ✅ Admin-only routes
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
 


### PR DESCRIPTION
## Summary
- Permit SockJS `/ws/**` endpoint in security config so websocket connections can initialize

## Testing
- `mvn -f Backend/backend/pom.xml -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68990d98fb7c83339392517db191af01