### PR TITLE
Format admin websocket notifications

### DIFF
--- a/Frontend/src/app/admin/admin-notifications/admin-notifications.component.html
+++ b/Frontend/src/app/admin/admin-notifications/admin-notifications.component.html
@@ -1,5 +1,5 @@
 <div class="fixed top-4 right-4 w-80 z-50">
   <div *ngFor="let note of notifications" class="bg-white shadow-md rounded p-3 mb-2 border border-gray-200">
-    {{ note }}
+    <p class="text-sm text-gray-800">{{ note }}</p>
   </div>
 </div>

--- a/Frontend/src/app/services/notification.service.ts
+++ b/Frontend/src/app/services/notification.service.ts
@@ -24,7 +24,15 @@ export class NotificationService {
     this.stompClient.connect({}, () => {
       this.stompClient?.subscribe('/topic/orders', (message: IMessage) => {
         if (message.body) {
-          this.notificationSubject.next(message.body);
+          try {
+            const data = JSON.parse(message.body);
+            const userEmail = data.userEmail ?? 'Unknown user';
+            const totalAmount = Number(data.totalAmount ?? 0).toFixed(2);
+            const formatted = `New order from ${userEmail} totaling R${totalAmount}`;
+            this.notificationSubject.next(formatted);
+          } catch (e) {
+            console.error('Failed to parse notification', e);
+          }
         }
       });
     });


### PR DESCRIPTION
## Summary
- Parse STOMP message bodies as JSON in NotificationService
- Show parsed order info in admin notifications panel

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68991312fb78833383eb962707091484