### PR TITLE
Send user-specific WebSocket order updates

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/config/WebSocketConfig.java
+++ b/Backend/backend/src/main/java/com/example/backend/config/WebSocketConfig.java
@@ -1,25 +1,82 @@
 package com.example.backend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic"); // Broker for subscriptions
-        config.setApplicationDestinationPrefixes("/app"); // Prefix for sending
+        config.enableSimpleBroker("/topic", "/queue");
+        config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                if (accessor != null) {
+                    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                        String authHeader = accessor.getFirstNativeHeader("Authorization");
+                        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                            String token = authHeader.substring(7);
+                            try {
+                                String username = jwtService.extractUsername(token);
+                                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                                if (jwtService.isTokenValid(token, userDetails)) {
+                                    String userId = jwtService.extractUserId(token).toString();
+                                    UsernamePasswordAuthenticationToken user = new UsernamePasswordAuthenticationToken(
+                                            userId,
+                                            null,
+                                            userDetails.getAuthorities()
+                                    );
+                                    accessor.setUser(user);
+                                }
+                            } catch (Exception ignored) {
+                            }
+                        }
+                    } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                        String destination = accessor.getDestination();
+                        String userId = accessor.getUser() != null ? accessor.getUser().getName() : null;
+                        if (destination != null && destination.startsWith("/topic/orders/")) {
+                            String destUserId = destination.substring("/topic/orders/".length());
+                            if (userId == null || !userId.equals(destUserId)) {
+                                throw new IllegalArgumentException("Forbidden subscription");
+                            }
+                        }
+                    }
+                }
+                return message;
+            }
+        });
     }
 }
 

--- a/Backend/backend/src/main/java/com/example/backend/service/OrderService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/OrderService.java
@@ -67,7 +67,11 @@ public class OrderService {
 
         Order saved = orderRepository.save(order);
         OrderDTO dto = convertToOrderDTO(saved);
-        messagingTemplate.convertAndSend("/topic/orders", dto);
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(user.getId()),
+                "/queue/orders",
+                dto
+        );
         return dto;
     }
 


### PR DESCRIPTION
## Summary
- deliver order updates via user-scoped WebSocket queue
- secure WebSocket channel with JWT-authenticated user principal
- subscribe frontend to authenticated user queue for notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68991315003c8333ba57a1b5e31a6bc7