### PR TITLE
Remove redundant footer from home page

### DIFF
--- a/Frontend/src/app/pages/home/home.component.html
+++ b/Frontend/src/app/pages/home/home.component.html
@@ -58,6 +58,4 @@
     </div>
   </div>
 
-  <!-- Fixed Footer -->
-  <app-footer class="fixed bottom-0 left-0 w-full"></app-footer>
-</div>
+  </div>


### PR DESCRIPTION
## Summary
- Remove `<app-footer>` from HomeComponent template to rely on global footer.

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68991ac151b083338ab0e22803b3c318