### PR TITLE
feat: add paginated admin order search and notifications throttle

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/AdminOrderController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/AdminOrderController.java
@@ -85,6 +85,21 @@ public class AdminOrderController {
         }
     }
 
+    // ✅ Search Orders with Pagination (Admin)
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/search")
+    public ResponseEntity<?> searchOrders(
+            @RequestParam(defaultValue = "") String query,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        try {
+            return ResponseEntity.ok(orderService.searchOrders(query, page, size));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("Error searching orders: " + e.getMessage());
+        }
+    }
+
     // ✅ Update Order Status (Admin)
     @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/update/{orderId}")

--- a/Backend/backend/src/main/java/com/example/backend/repository/OrderRepository.java
+++ b/Backend/backend/src/main/java/com/example/backend/repository/OrderRepository.java
@@ -3,6 +3,8 @@ package com.example.backend.repository;
 
 import com.example.backend.entity.Order;
 import com.example.backend.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +15,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByUserId(Long userId);
     List<Order> findByStatus(String status);
     List<Order> findByDriver(User driver);
+    Page<Order> findByUserEmailContainingIgnoreCase(String email, Pageable pageable);
 
 }
 

--- a/Backend/backend/src/main/java/com/example/backend/service/OrderService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/OrderService.java
@@ -112,6 +112,17 @@ public class OrderService {
                 .map(this::convertToOrderDTO);
     }
 
+    public Page<OrderDTO> searchOrders(String query, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("orderDate"));
+        Page<Order> orders;
+        if (query == null || query.isBlank()) {
+            orders = orderRepository.findAll(pageable);
+        } else {
+            orders = orderRepository.findByUserEmailContainingIgnoreCase(query, pageable);
+        }
+        return orders.map(this::convertToOrderDTO);
+    }
+
     @Transactional
     public OrderDTO updateOrderStatus(Long orderId, String status) {
         Order order = orderRepository.findById(orderId)

--- a/Frontend/src/app/admin/admin-orders/admin-orders.component.html
+++ b/Frontend/src/app/admin/admin-orders/admin-orders.component.html
@@ -2,24 +2,25 @@
 
     <h2 class="text-2xl font-bold mb-6 text-gray-800">📦 Orders Management</h2>
   
-    <!-- Filter Dropdown -->
+    <!-- Filter & Search -->
     <div class="flex justify-between mb-4 items-center">
       <label class="text-sm font-medium text-gray-700">
         Filter by Status:
-        <select [(ngModel)]="filterStatus" (change)="filterOrders()" class="ml-2 border px-3 py-1 rounded">
+        <select [(ngModel)]="filterStatus" (change)="fetchOrders(1)" class="ml-2 border px-3 py-1 rounded">
           <option value="All">All</option>
           <option value="Pending">Pending</option>
           <option value="In Progress">In Progress</option>
           <option value="Delivered">Delivered</option>
         </select>
       </label>
+      <input type="text" placeholder="Search" (input)="onSearch($event.target.value)" class="border px-3 py-1 rounded" />
     </div>
   
     <!-- Orders List -->
     <div *ngIf="loading" class="text-gray-500">Loading orders...</div>
     <div *ngIf="errorMessage" class="text-red-500">{{ errorMessage }}</div>
   
-    <div *ngFor="let order of paginatedOrders()" class="bg-white rounded-lg shadow p-4 mb-4 border border-gray-200">
+    <div *ngFor="let order of filteredOrders()" class="bg-white rounded-lg shadow p-4 mb-4 border border-gray-200">
       <div class="flex flex-col md:flex-row justify-between md:items-center mb-2">
         <div class="mb-2 md:mb-0">
           <p class="font-semibold text-lg text-gray-700">Order #{{ order.id }}</p>
@@ -44,13 +45,7 @@
     </div>
   
     <!-- Pagination -->
-    <div class="flex justify-center items-center mt-6 space-x-2">
-      <button (click)="prevPage()" [disabled]="currentPage === 1"
-              class="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-sm">Prev</button>
-      <span class="text-sm text-gray-600">Page {{ currentPage }} of {{ totalPages() }}</span>
-      <button (click)="nextPage()" [disabled]="currentPage === totalPages()"
-              class="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-sm">Next</button>
-    </div>
+    <app-pagination [currentPage]="currentPage" [totalPages]="totalPages" (pageChange)="onPageChange($event)"></app-pagination>
   
     <!-- Modal -->
     <div *ngIf="selectedOrder" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/Frontend/src/app/admin/admin-orders/admin-orders.component.spec.ts
+++ b/Frontend/src/app/admin/admin-orders/admin-orders.component.spec.ts
@@ -1,14 +1,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
 
 import { AdminOrdersComponent } from './admin-orders.component';
+import { AdminService } from 'src/app/services/admin.service';
+import { PaginationComponent } from '../../components/pagination/pagination.component';
 
 describe('AdminOrdersComponent', () => {
   let component: AdminOrdersComponent;
   let fixture: ComponentFixture<AdminOrdersComponent>;
 
   beforeEach(() => {
+    const adminServiceStub = {
+      getOrders: () => of({ content: [], totalPages: 0 }),
+      updateOrderStatus: () => of(null),
+      getAvailableDrivers: () => of([]),
+      assignDriver: () => of(null)
+    };
+
     TestBed.configureTestingModule({
-      declarations: [AdminOrdersComponent]
+      declarations: [AdminOrdersComponent, PaginationComponent],
+      imports: [FormsModule],
+      providers: [{ provide: AdminService, useValue: adminServiceStub }]
     });
     fixture = TestBed.createComponent(AdminOrdersComponent);
     component = fixture.componentInstance;

--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { AuthInterceptor } from './authInterceptor/auth.interceptor';
 import { DriverMapComponent } from './driver/driver-map/driver-map.component';
 import { AdminNotificationsComponent } from './admin/admin-notifications/admin-notifications.component';
 import { AdminFooterComponent } from './admin/admin-footer/admin-footer.component';
+import { PaginationComponent } from './components/pagination/pagination.component';
 
 
 
@@ -52,6 +53,7 @@ import { AdminFooterComponent } from './admin/admin-footer/admin-footer.componen
     AdminFooterComponent,
     DriverDashboardComponent,
     DriverMapComponent,
+    PaginationComponent,
   ],
   imports: [
     BrowserModule,

--- a/Frontend/src/app/components/pagination/pagination.component.html
+++ b/Frontend/src/app/components/pagination/pagination.component.html
@@ -1,0 +1,5 @@
+<div class="flex justify-center items-center mt-6 space-x-2">
+  <button (click)="prev()" [disabled]="currentPage === 1" class="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-sm">Prev</button>
+  <span class="text-sm text-gray-600">Page {{ currentPage }} of {{ totalPages }}</span>
+  <button (click)="next()" [disabled]="currentPage === totalPages" class="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-sm">Next</button>
+</div>

--- a/Frontend/src/app/components/pagination/pagination.component.scss
+++ b/Frontend/src/app/components/pagination/pagination.component.scss
@@ -1,0 +1,1 @@
+/* Generic pagination styles can be extended as needed */

--- a/Frontend/src/app/components/pagination/pagination.component.ts
+++ b/Frontend/src/app/components/pagination/pagination.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-pagination',
+  templateUrl: './pagination.component.html',
+  styleUrls: ['./pagination.component.scss']
+})
+export class PaginationComponent {
+  @Input() currentPage = 1;
+  @Input() totalPages = 1;
+  @Output() pageChange = new EventEmitter<number>();
+
+  next(): void {
+    if (this.currentPage < this.totalPages) {
+      this.pageChange.emit(this.currentPage + 1);
+    }
+  }
+
+  prev(): void {
+    if (this.currentPage > 1) {
+      this.pageChange.emit(this.currentPage - 1);
+    }
+  }
+}

--- a/Frontend/src/app/services/admin.service.ts
+++ b/Frontend/src/app/services/admin.service.ts
@@ -33,6 +33,18 @@ export class AdminService {
     });
   }
 
+  // ✅ Get paginated & searchable orders
+  getOrders(page: number, size: number, query: string): Observable<any> {
+    const params: any = { page, size };
+    if (query) {
+      params.query = query;
+    }
+    return this.http.get(`${this.baseUrl}/orders/search`, {
+      headers: this.getAuthHeaders(),
+      params
+    });
+  }
+
   // ✅ Get all menu items
   getMenuItems(): Observable<any> {
     return this.http.get(`${this.baseUrl}/menu`, {

--- a/Frontend/src/app/services/notification.service.ts
+++ b/Frontend/src/app/services/notification.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { CompatClient, IMessage, Stomp } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 import { Observable, Subject } from 'rxjs';
+import { throttleTime } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 import { ToastrService } from 'ngx-toastr';
 
@@ -49,6 +50,6 @@ export class NotificationService {
   }
 
   get notifications(): Observable<string> {
-    return this.notificationSubject.asObservable();
+    return this.notificationSubject.asObservable().pipe(throttleTime(1000));
   }
 }


### PR DESCRIPTION
## Summary
- throttle WebSocket notifications to 1 second using rxjs `throttleTime`
- add search & pagination endpoint for admin orders
- refactor admin orders UI to use debounced search and reusable pagination component

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_689921a7aaa08333b899b9378a396cdc