### PR TITLE
feat: add optimistic updates for admin actions

### DIFF
--- a/Frontend/src/app/admin/admin-menu/admin-menu.component.ts
+++ b/Frontend/src/app/admin/admin-menu/admin-menu.component.ts
@@ -28,17 +28,15 @@ export class AdminMenuComponent implements OnInit {
   constructor(private adminService: AdminService) {}
 
   ngOnInit(): void {
+    this.adminService.menuItems$.subscribe(data => {
+      this.menuItems = data;
+      this.categories = ['All', ...Array.from(new Set<string>(data.map((item: any) => item.category)))];
+    });
     this.fetchMenuItems();
   }
 
   fetchMenuItems(): void {
-    this.adminService.getMenuItems().subscribe({
-      next: data => {
-        this.menuItems = data;
-        this.categories = ['All', ...Array.from(new Set<string>((data.map((item: any) => item.category))))];
-
-
-      },
+    this.adminService.loadMenuItems().subscribe({
       error: err => console.error('Failed to fetch menu items:', err)
     });
   }
@@ -68,17 +66,12 @@ export class AdminMenuComponent implements OnInit {
       return;
     }
 
-    const action = this.isEditing
-      ? this.adminService.updateMenuItem(this.formData.id!, this.formData)
-      : this.adminService.createMenuItem(this.formData);
-
-    action.subscribe({
-      next: () => {
-        this.fetchMenuItems();
-        this.toggleForm();
-      },
-      error: err => console.error('Error saving menu item:', err)
-    });
+    if (this.isEditing) {
+      this.adminService.updateMenuItem(this.formData.id!, this.formData);
+    } else {
+      this.adminService.createMenuItem(this.formData);
+    }
+    this.toggleForm();
   }
 
   editItem(item: any): void {
@@ -89,10 +82,7 @@ export class AdminMenuComponent implements OnInit {
 
   deleteItem(id: number): void {
     if (confirm('Are you sure you want to delete this item?')) {
-      this.adminService.deleteMenuItem(id).subscribe({
-        next: () => this.fetchMenuItems(),
-        error: err => console.error('Error deleting item:', err)
-      });
+      this.adminService.deleteMenuItem(id);
     }
   }
 

--- a/Frontend/src/app/pages/home/home.component.ts
+++ b/Frontend/src/app/pages/home/home.component.ts
@@ -40,17 +40,23 @@ export class HomeComponent {
   }
 
   fetchMenu(): void {
-    const source = this.isAdmin
-      ? this.adminService.getMenuItems()
-      : this.menuService.getMenuItems();
-
-    source.subscribe({
-      next: (data) => {
+    if (this.isAdmin) {
+      this.adminService.menuItems$.subscribe((data: any[]) => {
         this.menuItems = data;
         this.filteredMenuItems = data;
-      },
-      error: (err) => console.error('❌ Failed to load menu:', err)
-    });
+      });
+      this.adminService.loadMenuItems().subscribe({
+        error: (err) => console.error('❌ Failed to load menu:', err)
+      });
+    } else {
+      this.menuService.getMenuItems().subscribe({
+        next: (data: any[]) => {
+          this.menuItems = data;
+          this.filteredMenuItems = data;
+        },
+        error: (err) => console.error('❌ Failed to load menu:', err)
+      });
+    }
   }
 
   filterMenu(): void {

--- a/Frontend/src/app/services/admin.service.spec.ts
+++ b/Frontend/src/app/services/admin.service.spec.ts
@@ -1,12 +1,20 @@
 import { TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ToastrService } from 'ngx-toastr';
 import { AdminService } from './admin.service';
+import { OptimisticService } from './optimistic.service';
 
 describe('AdminService', () => {
   let service: AdminService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        OptimisticService,
+        { provide: ToastrService, useValue: { success: () => {}, error: () => {} } }
+      ]
+    });
     service = TestBed.inject(AdminService);
   });
 

--- a/Frontend/src/app/services/optimistic.service.ts
+++ b/Frontend/src/app/services/optimistic.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ToastrService } from 'ngx-toastr';
+
+interface QueueItem<T> {
+  request$: Observable<T>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class OptimisticService {
+  private queue: QueueItem<any>[] = [];
+
+  constructor(private toastr: ToastrService) {}
+
+  /**
+   * Apply a local change immediately, enqueue the server request
+   * and reconcile when the response arrives.
+   */
+  enqueue<T>(
+    localUpdate: () => void,
+    request$: Observable<T>,
+    rollback: () => void,
+    successMessage: string,
+    errorMessage: string
+  ): void {
+    // Apply local update
+    localUpdate();
+
+    // Track request in queue
+    this.queue.push({ request$ });
+
+    request$.subscribe({
+      next: () => {
+        this.queue.shift();
+        this.toastr.success(successMessage);
+      },
+      error: () => {
+        this.queue.shift();
+        rollback();
+        this.toastr.error(errorMessage);
+      }
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add generic OptimisticService to queue server reconciliation and show toast messages
- make AdminService update order status and menu inventory optimistically
- adapt admin components and home page to use the new local state streams

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689921a494508333b708186799fe69c3