### PR TITLE
Add admin analytics dashboard with backend endpoints

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/AnalyticsController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/AnalyticsController.java
@@ -1,0 +1,44 @@
+package com.example.backend.controller;
+
+import com.example.backend.entity.SalesTrendDTO;
+import com.example.backend.entity.TopProductDTO;
+import com.example.backend.service.AnalyticsService;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/analytics")
+public class AnalyticsController {
+    private final AnalyticsService analyticsService;
+
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    @GetMapping("/sales-trends")
+    public List<SalesTrendDTO> salesTrends(@RequestParam String startDate, @RequestParam String endDate) {
+        return analyticsService.getSalesTrends(Instant.parse(startDate), Instant.parse(endDate));
+    }
+
+    @GetMapping("/top-products")
+    public List<TopProductDTO> topProducts(@RequestParam String startDate, @RequestParam String endDate) {
+        return analyticsService.getTopProducts(Instant.parse(startDate), Instant.parse(endDate));
+    }
+
+    @GetMapping("/aov")
+    public double averageOrderValue(@RequestParam String startDate, @RequestParam String endDate) {
+        return analyticsService.getAverageOrderValue(Instant.parse(startDate), Instant.parse(endDate));
+    }
+
+    @GetMapping("/on-time")
+    public double onTime(@RequestParam String startDate, @RequestParam String endDate) {
+        return analyticsService.getOnTimePercentage(Instant.parse(startDate), Instant.parse(endDate));
+    }
+
+    @GetMapping("/cancellations")
+    public double cancellations(@RequestParam String startDate, @RequestParam String endDate) {
+        return analyticsService.getCancellationRate(Instant.parse(startDate), Instant.parse(endDate));
+    }
+}

--- a/Backend/backend/src/main/java/com/example/backend/entity/SalesTrendDTO.java
+++ b/Backend/backend/src/main/java/com/example/backend/entity/SalesTrendDTO.java
@@ -1,0 +1,13 @@
+package com.example.backend.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SalesTrendDTO {
+    private String date;
+    private Double total;
+}

--- a/Backend/backend/src/main/java/com/example/backend/entity/TopProductDTO.java
+++ b/Backend/backend/src/main/java/com/example/backend/entity/TopProductDTO.java
@@ -1,0 +1,13 @@
+package com.example.backend.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TopProductDTO {
+    private String name;
+    private Long quantity;
+}

--- a/Backend/backend/src/main/java/com/example/backend/repository/OrderRepository.java
+++ b/Backend/backend/src/main/java/com/example/backend/repository/OrderRepository.java
@@ -6,6 +6,7 @@ import com.example.backend.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 
 @Repository
@@ -13,6 +14,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByUserId(Long userId);
     List<Order> findByStatus(String status);
     List<Order> findByDriver(User driver);
+    List<Order> findByOrderDateBetween(Instant start, Instant end);
 
 }
 

--- a/Backend/backend/src/main/java/com/example/backend/service/AnalyticsService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/AnalyticsService.java
@@ -1,0 +1,72 @@
+package com.example.backend.service;
+
+import com.example.backend.entity.Order;
+import com.example.backend.entity.OrderItem;
+import com.example.backend.entity.SalesTrendDTO;
+import com.example.backend.entity.TopProductDTO;
+import com.example.backend.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class AnalyticsService {
+    private final OrderRepository orderRepository;
+
+    public AnalyticsService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    public List<SalesTrendDTO> getSalesTrends(Instant start, Instant end) {
+        List<Order> orders = orderRepository.findByOrderDateBetween(start, end);
+        Map<LocalDate, Double> map = new TreeMap<>();
+        for (Order order : orders) {
+            LocalDate date = LocalDate.ofInstant(order.getOrderDate(), ZoneId.systemDefault());
+            map.merge(date, order.getTotalAmount(), Double::sum);
+        }
+        return map.entrySet().stream()
+                .map(e -> new SalesTrendDTO(e.getKey().toString(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    public List<TopProductDTO> getTopProducts(Instant start, Instant end) {
+        List<Order> orders = orderRepository.findByOrderDateBetween(start, end);
+        Map<String, Long> counts = new HashMap<>();
+        for (Order order : orders) {
+            for (OrderItem item : order.getOrderItems()) {
+                String name = item.getMenuItem().getName();
+                counts.merge(name, (long) item.getQuantity(), Long::sum);
+            }
+        }
+        return counts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(5)
+                .map(e -> new TopProductDTO(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    public double getAverageOrderValue(Instant start, Instant end) {
+        List<Order> orders = orderRepository.findByOrderDateBetween(start, end);
+        if (orders.isEmpty()) return 0;
+        double total = orders.stream().mapToDouble(Order::getTotalAmount).sum();
+        return total / orders.size();
+    }
+
+    public double getOnTimePercentage(Instant start, Instant end) {
+        List<Order> orders = orderRepository.findByOrderDateBetween(start, end);
+        if (orders.isEmpty()) return 0;
+        long delivered = orders.stream().filter(o -> "Delivered".equalsIgnoreCase(o.getStatus())).count();
+        return (delivered * 100.0) / orders.size();
+    }
+
+    public double getCancellationRate(Instant start, Instant end) {
+        List<Order> orders = orderRepository.findByOrderDateBetween(start, end);
+        if (orders.isEmpty()) return 0;
+        long cancelled = orders.stream().filter(o -> "Cancelled".equalsIgnoreCase(o.getStatus())).count();
+        return (cancelled * 100.0) / orders.size();
+    }
+}

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -39,7 +39,9 @@
     "tslib": "^2.8.1",
     "util": "^0.12.5",
     "vm-browserify": "^1.1.2",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.13.0",
+    "chart.js": "^4.4.0",
+    "ng2-charts": "^5.0.1"
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^16.0.1",

--- a/Frontend/src/app/admin/admin-dashboard/admin-dashboard.component.html
+++ b/Frontend/src/app/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,36 +1,40 @@
 <app-admin-notifications></app-admin-notifications>
-<div class="min-h-screen bg-gray-100 p-4">
-    <div class="max-w-5xl mx-auto">
-      <h2 class="text-2xl font-bold text-gray-800 mb-6">📊 Admin Dashboard</h2>
-  
-      <!-- Stats Cards -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-6">
-        <div class="bg-white p-4 rounded-lg shadow-md">
-          <p class="text-gray-600 text-sm">Total Orders</p>
-          <p class="text-2xl font-bold text-gray-800 mt-1">{{ totalOrders }}</p>
-        </div>
-        <div class="bg-white p-4 rounded-lg shadow-md">
-          <p class="text-gray-600 text-sm">Total Revenue</p>
-          <p class="text-2xl font-bold text-green-600 mt-1">R{{ totalRevenue.toFixed(2) }}</p>
-        </div>
-        <div class="bg-white p-4 rounded-lg shadow-md">
-          <p class="text-gray-600 text-sm">Pending Orders</p>
-          <p class="text-2xl font-bold text-orange-500 mt-1">{{ pendingOrders }}</p>
-        </div>
-      </div>
-  
-      <!-- Quick Links -->
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <a routerLink="/admin/orders" class="block bg-red-600 text-white p-4 rounded-lg shadow text-center hover:bg-red-700 transition">
-          🔍 Manage Orders
-        </a>
-        <a routerLink="/admin/menu" class="block bg-gray-700 text-white p-4 rounded-lg shadow text-center hover:bg-gray-800 transition">
-          🍔 Manage Menu
-        </a>
-        <a routerLink="/admin/drivers" class="block bg-blue-600 text-white p-4 rounded-lg shadow text-center hover:bg-blue-700 transition">
-          🚚 Manage Drivers
-        </a>
-      </div>
+<div class="p-4">
+  <div class="flex gap-2 mb-4">
+    <input type="date" [(ngModel)]="startDate" (change)="loadAnalytics()" class="border p-2 rounded" />
+    <input type="date" [(ngModel)]="endDate" (change)="loadAnalytics()" class="border p-2 rounded" />
+  </div>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div class="bg-white p-4 shadow rounded">
+      <canvas id="salesChart"></canvas>
+    </div>
+    <div class="bg-white p-4 shadow rounded">
+      <canvas id="productsChart"></canvas>
     </div>
   </div>
-  
+
+  <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="bg-white p-4 shadow rounded">Average Order Value: {{ aov | number:'1.2-2' }}</div>
+    <div class="bg-white p-4 shadow rounded">On-time %: {{ onTime | number:'1.0-0' }}%</div>
+    <div class="bg-white p-4 shadow rounded">Cancellations: {{ cancellations | number:'1.0-0' }}%</div>
+  </div>
+
+  <div class="mt-6">
+    <h3 class="font-semibold mb-2">Top Products</h3>
+    <table class="min-w-full bg-white shadow rounded">
+      <thead>
+        <tr class="text-left">
+          <th class="p-2">Product</th>
+          <th class="p-2">Quantity</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let p of topProducts" class="border-t">
+          <td class="p-2">{{ p.name }}</td>
+          <td class="p-2">{{ p.quantity }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/Frontend/src/app/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/Frontend/src/app/admin/admin-dashboard/admin-dashboard.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { AdminService } from 'src/app/services/admin.service';
-import { AdminNotificationsComponent } from '../admin-notifications/admin-notifications.component';
+import { Chart } from 'chart.js/auto';
+import { AnalyticsService } from './analytics.service';
 
 @Component({
   selector: 'app-admin-dashboard',
@@ -9,27 +8,53 @@ import { AdminNotificationsComponent } from '../admin-notifications/admin-notifi
   styleUrls: ['./admin-dashboard.component.scss']
 })
 export class AdminDashboardComponent implements OnInit {
+  startDate!: string;
+  endDate!: string;
 
-totalOrders: number = 0;
-totalRevenue: number = 0;
-pendingOrders: number = 0;
+  salesChart?: Chart;
+  productsChart?: Chart;
+  topProducts: any[] = [];
+  aov = 0;
+  onTime = 0;
+  cancellations = 0;
 
-constructor(private adminService: AdminService) {}
+  constructor(private analyticsService: AnalyticsService) {}
 
-ngOnInit(): void {
-  this.loadStats();
-}
+  ngOnInit(): void {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    this.startDate = start.toISOString().substring(0,10);
+    this.endDate = now.toISOString().substring(0,10);
+    this.loadAnalytics();
+  }
 
-loadStats() {
-  this.adminService.getDashboardStats().subscribe({
-    next: (stats) => {
-      this.totalOrders = stats.totalOrders;
-      this.totalRevenue = stats.totalRevenue;
-      this.pendingOrders = stats.pendingOrders;
-    },
-    error: () => {
-      console.error('Error loading admin stats');
-    }
-  });
-}
+  loadAnalytics() {
+    const start = new Date(this.startDate).toISOString();
+    const end = new Date(this.endDate).toISOString();
+
+    this.analyticsService.getSalesTrends(start, end).subscribe(data => {
+      const labels = data.map(d => d.date);
+      const values = data.map(d => d.total);
+      if (this.salesChart) this.salesChart.destroy();
+      this.salesChart = new Chart('salesChart', {
+        type: 'line',
+        data: { labels, datasets: [{ label: 'Sales', data: values, borderColor: '#4f46e5' }] }
+      });
+    });
+
+    this.analyticsService.getTopProducts(start, end).subscribe(data => {
+      this.topProducts = data;
+      const labels = data.map(d => d.name);
+      const values = data.map(d => d.quantity);
+      if (this.productsChart) this.productsChart.destroy();
+      this.productsChart = new Chart('productsChart', {
+        type: 'bar',
+        data: { labels, datasets: [{ label: 'Top Products', data: values, backgroundColor: '#10b981' }] }
+      });
+    });
+
+    this.analyticsService.getAverageOrderValue(start, end).subscribe(v => this.aov = v);
+    this.analyticsService.getOnTimePercentage(start, end).subscribe(v => this.onTime = v);
+    this.analyticsService.getCancellationRate(start, end).subscribe(v => this.cancellations = v);
+  }
 }

--- a/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgChartsModule } from 'ng2-charts';
+import { AdminDashboardComponent } from './admin-dashboard.component';
+
+@NgModule({
+  declarations: [AdminDashboardComponent],
+  imports: [CommonModule, FormsModule, NgChartsModule],
+  exports: [AdminDashboardComponent]
+})
+export class AdminDashboardModule {}

--- a/Frontend/src/app/admin/admin-dashboard/analytics.service.ts
+++ b/Frontend/src/app/admin/admin-dashboard/analytics.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AnalyticsService {
+  private baseUrl = '/api/admin/analytics';
+
+  constructor(private http: HttpClient) {}
+
+  getSalesTrends(startDate: string, endDate: string): Observable<any[]> {
+    const params = new HttpParams().set('startDate', startDate).set('endDate', endDate);
+    return this.http.get<any[]>(`${this.baseUrl}/sales-trends`, { params });
+  }
+
+  getTopProducts(startDate: string, endDate: string): Observable<any[]> {
+    const params = new HttpParams().set('startDate', startDate).set('endDate', endDate);
+    return this.http.get<any[]>(`${this.baseUrl}/top-products`, { params });
+  }
+
+  getAverageOrderValue(startDate: string, endDate: string): Observable<number> {
+    const params = new HttpParams().set('startDate', startDate).set('endDate', endDate);
+    return this.http.get<number>(`${this.baseUrl}/aov`, { params });
+  }
+
+  getOnTimePercentage(startDate: string, endDate: string): Observable<number> {
+    const params = new HttpParams().set('startDate', startDate).set('endDate', endDate);
+    return this.http.get<number>(`${this.baseUrl}/on-time`, { params });
+  }
+
+  getCancellationRate(startDate: string, endDate: string): Observable<number> {
+    const params = new HttpParams().set('startDate', startDate).set('endDate', endDate);
+    return this.http.get<number>(`${this.baseUrl}/cancellations`, { params });
+  }
+}

--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -18,7 +18,7 @@ import { ProductComponent } from './pages/product/product.component';
 import { CheckoutComponent } from './pages/checkout/checkout.component';
 import { ThankYouComponent } from './components/thank-you/thank-you.component';
 import { HistoryordersComponent } from './pages/historyorders/historyorders.component';
-import { AdminDashboardComponent } from './admin/admin-dashboard/admin-dashboard.component';
+import { AdminDashboardModule } from './admin/admin-dashboard/admin-dashboard.module';
 import { AdminOrdersComponent } from './admin/admin-orders/admin-orders.component';
 import { AdminMenuComponent } from './admin/admin-menu/admin-menu.component';
 import { AdminDriversComponent } from './admin/admin-drivers/admin-drivers.component';
@@ -44,7 +44,6 @@ import { AdminFooterComponent } from './admin/admin-footer/admin-footer.componen
     CheckoutComponent,
     ThankYouComponent,
     HistoryordersComponent,
-    AdminDashboardComponent,
     AdminOrdersComponent,
     AdminMenuComponent,
     AdminDriversComponent,
@@ -60,6 +59,7 @@ import { AdminFooterComponent } from './admin/admin-footer/admin-footer.componen
     FormsModule,
     ReactiveFormsModule,
     BrowserAnimationsModule,
+    AdminDashboardModule,
     ToastrModule.forRoot({
       positionClass: 'toast-bottom-right',
       timeOut: 4000,


### PR DESCRIPTION
## Summary
- add Chart.js and module for admin analytics dashboard
- implement Angular analytics service and chart-based dashboard with date filters
- expose backend analytics endpoints for sales trends, top products, and order metrics

## Testing
- `npm test -- --watch=false` *(fails: Cannot resolve 'chart.js/auto')*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689921a225008333b680bd334a88d10f