### PR TITLE
Add admin driver tracking map and websocket integration

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/AdminDriverController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/AdminDriverController.java
@@ -2,6 +2,7 @@ package com.example.backend.controller;
 
 import com.example.backend.auth.RegisterRequest;
 import com.example.backend.entity.DriverDTO;
+import com.example.backend.entity.DriverLocationDTO;
 import com.example.backend.service.AdminDriverService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,11 @@ public class AdminDriverController {
     public ResponseEntity<?> deleteDriver(@PathVariable Long id) {
         adminDriverService.deleteDriver(id);
         return ResponseEntity.ok(Map.of("message", "Driver deleted"));
+    }
+
+    @GetMapping("/locations")
+    public ResponseEntity<List<DriverLocationDTO>> getDriverLocations() {
+        return ResponseEntity.ok(adminDriverService.getDriverLocations());
     }
 }
 

--- a/Backend/backend/src/main/java/com/example/backend/controller/DriverLocationWsController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/DriverLocationWsController.java
@@ -1,0 +1,30 @@
+package com.example.backend.controller;
+
+import com.example.backend.entity.DriverLocationDTO;
+import com.example.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+import java.time.Instant;
+
+@Controller
+@RequiredArgsConstructor
+public class DriverLocationWsController {
+    private final UserRepository userRepository;
+
+    @MessageMapping("/drivers")
+    @SendTo("/topic/drivers")
+    public DriverLocationDTO updateLocation(DriverLocationDTO location) {
+        userRepository.findById(location.getId()).ifPresent(user -> {
+            user.setLatitude(location.getLatitude());
+            user.setLongitude(location.getLongitude());
+            user.setSpeed(location.getSpeed());
+            user.setLastPing(Instant.now());
+            userRepository.save(user);
+        });
+        location.setLastPing(Instant.now());
+        return location;
+    }
+}

--- a/Backend/backend/src/main/java/com/example/backend/entity/DriverLocationDTO.java
+++ b/Backend/backend/src/main/java/com/example/backend/entity/DriverLocationDTO.java
@@ -1,0 +1,21 @@
+package com.example.backend.entity;
+
+import com.example.backend.user.DriverStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DriverLocationDTO {
+    private Long id;
+    private String email;
+    private DriverStatus driverStatus;
+    private Double latitude;
+    private Double longitude;
+    private Double speed;
+    private Instant lastPing;
+}

--- a/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/AdminDriverService.java
@@ -2,6 +2,7 @@ package com.example.backend.service;
 
 import com.example.backend.auth.RegisterRequest;
 import com.example.backend.entity.DriverDTO;
+import com.example.backend.entity.DriverLocationDTO;
 import com.example.backend.repository.UserRepository;
 import com.example.backend.user.DriverStatus;
 import com.example.backend.user.Role;
@@ -12,6 +13,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,11 +45,25 @@ public class AdminDriverService {
                 .toList();
     }
 
-    public void deleteDriver(Long id) {
-        if (!userRepository.existsById(id)) {
-            throw new RuntimeException("Driver not found");
-        }
-        userRepository.deleteById(id);
-    }
+  public void deleteDriver(Long id) {
+      if (!userRepository.existsById(id)) {
+          throw new RuntimeException("Driver not found");
+      }
+      userRepository.deleteById(id);
+  }
+
+  public List<DriverLocationDTO> getDriverLocations() {
+      return userRepository.findByRole(Role.DRIVER).stream()
+              .map(u -> new DriverLocationDTO(
+                      u.getId(),
+                      u.getEmail(),
+                      u.getDriverStatus(),
+                      u.getLatitude(),
+                      u.getLongitude(),
+                      u.getSpeed(),
+                      u.getLastPing()
+              ))
+              .collect(Collectors.toList());
+  }
 }
 

--- a/Backend/backend/src/main/java/com/example/backend/user/User.java
+++ b/Backend/backend/src/main/java/com/example/backend/user/User.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -36,8 +37,13 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Enumerated(EnumType.STRING)
-    private DriverStatus driverStatus;
+  @Enumerated(EnumType.STRING)
+  private DriverStatus driverStatus;
+
+  private Double latitude;
+  private Double longitude;
+  private Double speed;
+  private Instant lastPing;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore // Prevent serialization of orders in user

--- a/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.html
+++ b/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.html
@@ -1,0 +1,9 @@
+<div class="driver-map-wrapper">
+  <div class="filter-controls mb-2">
+    <label class="mr-4" *ngFor="let status of ['AVAILABLE','UNAVAILABLE']">
+      <input type="checkbox" [checked]="selectedStatuses.has(status)" (change)="toggleStatus(status, $event)" />
+      {{status}}
+    </label>
+  </div>
+  <div id="adminDriverMap" class="map-container"></div>
+</div>

--- a/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.scss
+++ b/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.scss
@@ -1,0 +1,9 @@
+.driver-map-wrapper {
+  width: 100%;
+  height: 600px;
+}
+
+.map-container {
+  width: 100%;
+  height: 100%;
+}

--- a/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.ts
+++ b/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.ts
@@ -1,0 +1,219 @@
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
+import { AdminService } from 'src/app/services/admin.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { Stomp } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+import maplibregl, { Map, GeoJSONSource, LngLatLike } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+interface DriverLocation {
+  id: number;
+  email: string;
+  driverStatus: string;
+  latitude: number;
+  longitude: number;
+  speed: number;
+  lastPing: string;
+}
+
+@Component({
+  selector: 'app-admin-driver-map',
+  templateUrl: './admin-driver-map.component.html',
+  styleUrls: ['./admin-driver-map.component.scss']
+})
+export class AdminDriverMapComponent implements AfterViewInit, OnDestroy {
+  private map!: Map;
+  private stompClient: any;
+  private drivers: Record<number, any> = {};
+  private replayLength = 5;
+  selectedStatuses = new Set<string>(['AVAILABLE', 'UNAVAILABLE']);
+
+  constructor(private adminService: AdminService, private authService: AuthService) {}
+
+  ngAfterViewInit(): void {
+    this.initMap();
+    this.loadInitialLocations();
+    this.connectWebSocket();
+  }
+
+  ngOnDestroy(): void {
+    if (this.stompClient) {
+      this.stompClient.disconnect();
+    }
+    if (this.map) {
+      this.map.remove();
+    }
+  }
+
+  toggleStatus(status: string, event: any): void {
+    if (event.target.checked) {
+      this.selectedStatuses.add(status);
+    } else {
+      this.selectedStatuses.delete(status);
+    }
+    this.refreshSource();
+  }
+
+  private initMap(): void {
+    this.map = new maplibregl.Map({
+      container: 'adminDriverMap',
+      style: 'https://demotiles.maplibre.org/style.json',
+      center: [28.0473, -26.2041] as LngLatLike,
+      zoom: 9
+    });
+
+    this.map.on('load', () => {
+      this.map.addSource('drivers', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+        cluster: true,
+        clusterMaxZoom: 14,
+        clusterRadius: 50
+      });
+
+      this.map.addLayer({
+        id: 'clusters',
+        type: 'circle',
+        source: 'drivers',
+        filter: ['has', 'point_count'],
+        paint: {
+          'circle-color': '#51bbd6',
+          'circle-radius': ['step', ['get', 'point_count'], 15, 10, 20, 25, 25]
+        }
+      });
+
+      this.map.addLayer({
+        id: 'cluster-count',
+        type: 'symbol',
+        source: 'drivers',
+        filter: ['has', 'point_count'],
+        layout: {
+          'text-field': ['get', 'point_count_abbreviated'],
+          'text-font': ['Open Sans Bold'],
+          'text-size': 12
+        }
+      });
+
+      this.map.addLayer({
+        id: 'unclustered-point',
+        type: 'circle',
+        source: 'drivers',
+        filter: ['!', ['has', 'point_count']],
+        paint: {
+          'circle-color': '#11b4da',
+          'circle-radius': 8,
+          'circle-stroke-width': 1,
+          'circle-stroke-color': '#fff'
+        }
+      });
+
+      this.map.on('click', 'unclustered-point', e => {
+        const feature = e.features && e.features[0];
+        if (!feature) return;
+        const id = feature.properties && feature.properties['id'];
+        const driver = this.drivers[id];
+        if (!driver) return;
+        const coords = feature.geometry['coordinates'];
+        new maplibregl.Popup()
+          .setLngLat(coords as LngLatLike)
+          .setHTML(this.popupHtml(driver))
+          .addTo(this.map);
+      });
+    });
+  }
+
+  private popupHtml(driver: any): string {
+    const eta = driver.speed > 0 && driver.history.length > 1
+      ? (this.computeDistance(driver.history.at(-2), driver.history.at(-1)) / driver.speed * 60).toFixed(1)
+      : 'N/A';
+    return `<div><strong>${driver.email}</strong><br>Status: ${driver.driverStatus}<br>Speed: ${driver.speed?.toFixed(1) || '0'} km/h<br>ETA: ${eta} min</div>`;
+  }
+
+  private computeDistance(a: [number, number], b: [number, number]): number {
+    const toRad = (n: number) => (n * Math.PI) / 180;
+    const R = 6371; // km
+    const dLat = toRad(b[1] - a[1]);
+    const dLon = toRad(b[0] - a[0]);
+    const lat1 = toRad(a[1]);
+    const lat2 = toRad(b[1]);
+    const aVal = Math.sin(dLat / 2) * Math.sin(dLat / 2) + Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+    const c = 2 * Math.atan2(Math.sqrt(aVal), Math.sqrt(1 - aVal));
+    return R * c;
+  }
+
+  private loadInitialLocations(): void {
+    this.adminService.getDriverLocations().subscribe(data => {
+      data.forEach(d => {
+        this.drivers[d.id] = { ...d, history: [[d.longitude, d.latitude]] };
+      });
+      this.refreshSource();
+    });
+  }
+
+  private connectWebSocket(): void {
+    const socket = new SockJS('/ws');
+    this.stompClient = Stomp.over(socket);
+    this.stompClient.debug = () => {};
+    const headers: { [key: string]: string } = {};
+    const token = this.authService.getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    this.stompClient.connect(headers, () => {
+      this.stompClient.subscribe('/topic/drivers', (message: any) => {
+        const loc: DriverLocation = JSON.parse(message.body);
+        const driver = this.drivers[loc.id] || { history: [] };
+        driver.email = loc.email;
+        driver.driverStatus = loc.driverStatus;
+        driver.speed = loc.speed;
+        driver.lastPing = loc.lastPing;
+        driver.history.push([loc.longitude, loc.latitude]);
+        if (driver.history.length > this.replayLength) {
+          driver.history.shift();
+        }
+        this.drivers[loc.id] = driver;
+        this.refreshSource();
+        this.updateRoute(loc.id);
+      });
+    });
+  }
+
+  private refreshSource(): void {
+    const features = Object.values(this.drivers)
+      .filter((d: any) => this.selectedStatuses.has(d.driverStatus))
+      .map((d: any) => ({
+        type: 'Feature',
+        properties: { id: d.id, driverStatus: d.driverStatus, email: d.email },
+        geometry: {
+          type: 'Point',
+          coordinates: d.history[d.history.length - 1]
+        }
+      }));
+    const source = this.map.getSource('drivers') as GeoJSONSource;
+    if (source) {
+      source.setData({ type: 'FeatureCollection', features });
+    }
+  }
+
+  private updateRoute(id: number): void {
+    const driver = this.drivers[id];
+    if (!driver || driver.history.length < 2) return;
+    const routeId = `route-${id}`;
+    const data = {
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: driver.history }
+    };
+    if (this.map.getSource(routeId)) {
+      (this.map.getSource(routeId) as GeoJSONSource).setData(data);
+    } else {
+      this.map.addSource(routeId, { type: 'geojson', data });
+      this.map.addLayer({
+        id: routeId,
+        type: 'line',
+        source: routeId,
+        paint: { 'line-color': '#f00', 'line-width': 2 }
+      });
+    }
+  }
+}
+

--- a/Frontend/src/app/admin/admin-drivers/admin-drivers.component.html
+++ b/Frontend/src/app/admin/admin-drivers/admin-drivers.component.html
@@ -11,25 +11,5 @@
     </button>
   </form>
 
-  <table class="w-full bg-white rounded shadow">
-    <thead>
-      <tr class="bg-gray-200 text-left">
-        <th class="p-2">Email</th>
-        <th class="p-2">Status</th>
-        <th class="p-2">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let driver of drivers" class="border-t">
-        <td class="p-2">{{ driver.email }}</td>
-        <td class="p-2">{{ driver.driverStatus }}</td>
-        <td class="p-2">
-          <button (click)="deleteDriver(driver.id)" class="text-red-600 hover:underline">Delete</button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div *ngIf="drivers.length === 0" class="text-center text-gray-500 mt-4">No drivers found.</div>
+  <app-admin-driver-map></app-admin-driver-map>
 </div>
-

--- a/Frontend/src/app/admin/admin-drivers/admin-drivers.component.spec.ts
+++ b/Frontend/src/app/admin/admin-drivers/admin-drivers.component.spec.ts
@@ -5,41 +5,29 @@ import { AdminService } from 'src/app/services/admin.service';
 import { AdminDriversComponent } from './admin-drivers.component';
 
 describe('AdminDriversComponent', () => {
-  let component: AdminDriversComponent;
-  let fixture: ComponentFixture<AdminDriversComponent>;
-  let adminServiceSpy: jasmine.SpyObj<AdminService>;
+    let component: AdminDriversComponent;
+    let fixture: ComponentFixture<AdminDriversComponent>;
+    let adminServiceSpy: jasmine.SpyObj<AdminService>;
 
-  beforeEach(() => {
-    adminServiceSpy = jasmine.createSpyObj('AdminService', ['getDrivers', 'createDriver', 'deleteDriver']);
-    adminServiceSpy.getDrivers.and.returnValue(of([]));
-    adminServiceSpy.createDriver.and.returnValue(of({}));
-    adminServiceSpy.deleteDriver.and.returnValue(of({}));
+    beforeEach(() => {
+      adminServiceSpy = jasmine.createSpyObj('AdminService', ['createDriver']);
+      adminServiceSpy.createDriver.and.returnValue(of({}));
 
-    TestBed.configureTestingModule({
-      declarations: [AdminDriversComponent],
-      imports: [FormsModule],
-      providers: [{ provide: AdminService, useValue: adminServiceSpy }]
+      TestBed.configureTestingModule({
+        declarations: [AdminDriversComponent],
+        imports: [FormsModule],
+        providers: [{ provide: AdminService, useValue: adminServiceSpy }]
+      });
+
+      fixture = TestBed.createComponent(AdminDriversComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
     });
 
-    fixture = TestBed.createComponent(AdminDriversComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    it('should call createDriver on addDriver', () => {
+      component.newDriver = { email: 'test@example.com', password: '123456' };
+      component.addDriver();
+      expect(adminServiceSpy.createDriver).toHaveBeenCalledWith(component.newDriver);
+    });
   });
-
-  it('should load drivers on init', () => {
-    expect(adminServiceSpy.getDrivers).toHaveBeenCalled();
-  });
-
-  it('should call createDriver on addDriver', () => {
-    component.newDriver = { email: 'test@example.com', password: '123456' };
-    component.addDriver();
-    expect(adminServiceSpy.createDriver).toHaveBeenCalledWith(component.newDriver);
-  });
-
-  it('should call deleteDriver when confirmed', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
-    component.deleteDriver(1);
-    expect(adminServiceSpy.deleteDriver).toHaveBeenCalledWith(1);
-  });
-});
 

--- a/Frontend/src/app/admin/admin-drivers/admin-drivers.component.ts
+++ b/Frontend/src/app/admin/admin-drivers/admin-drivers.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { AdminService } from 'src/app/services/admin.service';
 
 @Component({
@@ -6,46 +6,22 @@ import { AdminService } from 'src/app/services/admin.service';
   templateUrl: './admin-drivers.component.html',
   styleUrls: ['./admin-drivers.component.scss']
 })
-export class AdminDriversComponent implements OnInit {
-  drivers: any[] = [];
-  newDriver = { email: '', password: '' };
+  export class AdminDriversComponent {
+    newDriver = { email: '', password: '' };
 
-  constructor(private adminService: AdminService) {}
+    constructor(private adminService: AdminService) {}
 
-  ngOnInit(): void {
-    this.loadDrivers();
-  }
+    addDriver(): void {
+      if (!this.newDriver.email || !this.newDriver.password) {
+        return;
+      }
 
-  loadDrivers(): void {
-    this.adminService.getDrivers().subscribe({
-      next: data => (this.drivers = data),
-      error: err => console.error('Failed to load drivers', err)
-    });
-  }
-
-  addDriver(): void {
-    if (!this.newDriver.email || !this.newDriver.password) {
-      return;
+      this.adminService.createDriver(this.newDriver).subscribe({
+        next: () => {
+          this.newDriver = { email: '', password: '' };
+        },
+        error: err => console.error('Failed to create driver', err)
+      });
     }
-
-    this.adminService.createDriver(this.newDriver).subscribe({
-      next: () => {
-        this.newDriver = { email: '', password: '' };
-        this.loadDrivers();
-      },
-      error: err => console.error('Failed to create driver', err)
-    });
   }
-
-  deleteDriver(id: number): void {
-    if (!confirm('Are you sure you want to delete this driver?')) {
-      return;
-    }
-
-    this.adminService.deleteDriver(id).subscribe({
-      next: () => this.loadDrivers(),
-      error: err => console.error('Failed to delete driver', err)
-    });
-  }
-}
 

--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { AdminDashboardComponent } from './admin/admin-dashboard/admin-dashboard
 import { AdminOrdersComponent } from './admin/admin-orders/admin-orders.component';
 import { AdminMenuComponent } from './admin/admin-menu/admin-menu.component';
 import { AdminDriversComponent } from './admin/admin-drivers/admin-drivers.component';
+import { AdminDriverMapComponent } from './admin/admin-drivers/admin-driver-map.component';
 import { DriverDashboardComponent } from './driver/driver-dashboard/driver-dashboard.component';
 import { AuthInterceptor } from './authInterceptor/auth.interceptor';
 import { DriverMapComponent } from './driver/driver-map/driver-map.component';
@@ -48,6 +49,7 @@ import { AdminFooterComponent } from './admin/admin-footer/admin-footer.componen
     AdminOrdersComponent,
     AdminMenuComponent,
     AdminDriversComponent,
+    AdminDriverMapComponent,
     AdminNotificationsComponent,
     AdminFooterComponent,
     DriverDashboardComponent,

--- a/Frontend/src/app/services/admin.service.ts
+++ b/Frontend/src/app/services/admin.service.ts
@@ -94,6 +94,12 @@ export class AdminService {
     });
   }
 
+  getDriverLocations(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.baseUrl}/drivers/locations`, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
    // admin.service.ts
   assignDriver(orderId: number, driverId: number): Observable<any> {
   return this.http.post(


### PR DESCRIPTION
## Summary
- Replace driver list with new `AdminDriverMapComponent` using MapLibre, STOMP, clustering, status filters, and replay/ETA lines
- Track driver location, speed, and last ping via `/api/admin/drivers/locations` and `/topic/drivers` WebSocket

## Testing
- `./mvnw -q test` *(failed: Failed to fetch Maven)*
- `npm test` *(failed: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6899219fe8848333abf1eb9eb40c9de5