### PR TITLE
fix: close loadMenuItems method

### DIFF
--- a/Frontend/src/app/services/admin.service.ts
+++ b/Frontend/src/app/services/admin.service.ts
@@ -56,6 +56,7 @@ export class AdminService {
           return items;
         })
       );
+  }
   // ✅ Get paginated & searchable orders
   getOrders(page: number, size: number, query: string): Observable<any> {
     const params: any = { page, size };


### PR DESCRIPTION
## Summary
- close loadMenuItems after menu items fetch

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng: not found)*
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@kurkle%2fcolor)*

------
https://chatgpt.com/codex/tasks/task_e_68992a142660833386ec009c958df467