### PR TITLE
Add auth headers to getHealth in AdminService

### DIFF
--- a/Frontend/src/app/services/admin.service.ts
+++ b/Frontend/src/app/services/admin.service.ts
@@ -56,6 +56,8 @@ export class AdminService {
           return items;
         })
       );
+  }
+
   // ✅ Get paginated & searchable orders
   getOrders(page: number, size: number, query: string): Observable<any> {
     const params: any = { page, size };
@@ -210,6 +212,10 @@ export class AdminService {
 
   getHealth(): Observable<any> {
     return this.http.get(`${this.baseUrl}/health`, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
   // ✅ Inventory Management
   adjustInventory(adjustments: any[]): Observable<any> {
     return this.http.post(`${this.baseUrl}/inventory/adjust`, adjustments, {


### PR DESCRIPTION
## Summary
- Close `loadMenuItems` method
- Add auth headers to `getHealth` and close method so inventory functions sit at class level

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for @kurkle/color)*

------
https://chatgpt.com/codex/tasks/task_e_68992a16c4088333afa04ff53c7df439