### PR TITLE
Safely extract authorities in WebSocket subscriptions

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/config/WebSocketConfig.java
+++ b/Backend/backend/src/main/java/com/example/backend/config/WebSocketConfig.java
@@ -65,10 +65,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                         }
                     } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
                         String destination = accessor.getDestination();
-                        String userId = accessor.getUser() != null ? accessor.getUser().getName() : null;
-                        String role = accessor.getUser() != null && accessor.getUser().getAuthorities() != null
-                                ? accessor.getUser().getAuthorities().stream().findFirst().map(Object::toString).orElse(null)
-                                : null;
+                        java.security.Principal userPrincipal = accessor.getUser();
+                        String userId = userPrincipal != null ? userPrincipal.getName() : null;
+                        String role = null;
+                        if (userPrincipal instanceof UsernamePasswordAuthenticationToken) {
+                            UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) userPrincipal;
+                            role = token.getAuthorities().stream()
+                                    .findFirst()
+                                    .map(Object::toString)
+                                    .orElse(null);
+                        }
 
                         if (destination != null) {
                             if (destination.startsWith("/topic/orders/")) {


### PR DESCRIPTION
## Summary
- Obtain user role in WebSocket subscriptions by casting to `UsernamePasswordAuthenticationToken`
- Avoid calling `getAuthorities` on `Principal` directly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68992c56e3888333b5e4d37fe359d44e