### PR TITLE
fix: resolve admin orders search input parse error

### DIFF
--- a/Frontend/src/app/admin/admin-orders/admin-orders.component.html
+++ b/Frontend/src/app/admin/admin-orders/admin-orders.component.html
@@ -13,7 +13,7 @@
           <option value="Delivered">Delivered</option>
         </select>
       </label>
-      <input type="text" placeholder="Search" (input)="onSearch(($event.target as HTMLInputElement).value)" class="border px-3 py-1 rounded" />
+      <input type="text" placeholder="Search" (input)="onSearch($any($event.target).value)" class="border px-3 py-1 rounded" />
     </div>
   
     <!-- Orders List -->


### PR DESCRIPTION
## Summary
- replace unsupported template cast with $any to avoid search input parse error

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*
- `npm test --silent` *(fails: ng not found)*
- `npm install` *(fails: dependency tree could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68994441aeb48333aab9df660988a410