### PR TITLE
fix admin dashboard analytics service to use backend url

### DIFF
--- a/Frontend/src/app/admin/admin-dashboard/analytics.service.ts
+++ b/Frontend/src/app/admin/admin-dashboard/analytics.service.ts
@@ -6,7 +6,8 @@ import { Observable } from 'rxjs';
   providedIn: 'root'
 })
 export class AnalyticsService {
-  private baseUrl = '/api/admin/analytics';
+  // Use full backend URL since Angular dev server doesn't proxy /api requests
+  private baseUrl = 'http://localhost:8080/api/admin/analytics';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- fix admin analytics service to call backend on port 8080 so charts load

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng: not found)*
- `mvn -q test` *(fails: network is unreachable retrieving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68995222230c8333a6b76f112695d490