### PR TITLE
Fix top products analytics query

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/repository/OrderRepository.java
+++ b/Backend/backend/src/main/java/com/example/backend/repository/OrderRepository.java
@@ -2,10 +2,13 @@ package com.example.backend.repository;
 
 
 import com.example.backend.entity.Order;
+import com.example.backend.entity.TopProductDTO;
 import com.example.backend.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
@@ -18,6 +21,12 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByDriver(User driver);
     List<Order> findByOrderDateBetween(Instant start, Instant end);
     Page<Order> findByUserEmailContainingIgnoreCase(String email, Pageable pageable);
+
+    @Query("SELECT new com.example.backend.entity.TopProductDTO(oi.menuItem.name, SUM(oi.quantity)) " +
+           "FROM Order o JOIN o.orderItems oi " +
+           "WHERE o.status = 'Delivered' AND o.orderDate BETWEEN :start AND :end " +
+           "GROUP BY oi.menuItem.name ORDER BY SUM(oi.quantity) DESC")
+    List<TopProductDTO> findTopProducts(@Param("start") Instant start, @Param("end") Instant end, Pageable pageable);
 
 }
 

--- a/Backend/backend/src/main/java/com/example/backend/service/AnalyticsService.java
+++ b/Backend/backend/src/main/java/com/example/backend/service/AnalyticsService.java
@@ -1,10 +1,11 @@
 package com.example.backend.service;
 
 import com.example.backend.entity.Order;
-import com.example.backend.entity.OrderItem;
 import com.example.backend.entity.SalesTrendDTO;
 import com.example.backend.entity.TopProductDTO;
 import com.example.backend.repository.OrderRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -34,19 +35,8 @@ public class AnalyticsService {
     }
 
     public List<TopProductDTO> getTopProducts(Instant start, Instant end) {
-        List<Order> orders = orderRepository.findByOrderDateBetween(start, end);
-        Map<String, Long> counts = new HashMap<>();
-        for (Order order : orders) {
-            for (OrderItem item : order.getOrderItems()) {
-                String name = item.getMenuItem().getName();
-                counts.merge(name, (long) item.getQuantity(), Long::sum);
-            }
-        }
-        return counts.entrySet().stream()
-                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .limit(5)
-                .map(e -> new TopProductDTO(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
+        Pageable limit = PageRequest.of(0, 5);
+        return orderRepository.findTopProducts(start, end, limit);
     }
 
     public double getAverageOrderValue(Instant start, Instant end) {


### PR DESCRIPTION
## Summary
- Add repository query to compute top selling products for a date range
- Simplify analytics service to delegate to repository with limit

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.example:backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68995664d77883338bdbc2f0a9c41f2b