### PR TITLE
Fix STOMP client initialization

### DIFF
--- a/Frontend/src/app/admin/admin-diagnostics/admin-diagnostics.component.ts
+++ b/Frontend/src/app/admin/admin-diagnostics/admin-diagnostics.component.ts
@@ -33,8 +33,8 @@ export class AdminDiagnosticsComponent implements OnInit, OnDestroy {
   }
 
   private connect(): void {
-    const socket = new SockJS('http://localhost:8080/ws');
-    this.stompClient = Stomp.over(socket);
+    const socketFactory = () => new SockJS('http://localhost:8080/ws');
+    this.stompClient = Stomp.over(socketFactory);
     (this.stompClient as any).debug = () => {};
 
     const headers: { [key: string]: string } = {};

--- a/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.ts
+++ b/Frontend/src/app/admin/admin-drivers/admin-driver-map.component.ts
@@ -151,8 +151,8 @@ export class AdminDriverMapComponent implements AfterViewInit, OnDestroy {
   }
 
   private connectWebSocket(): void {
-    const socket = new SockJS('/ws');
-    this.stompClient = Stomp.over(socket);
+    const socketFactory = () => new SockJS('http://localhost:8080/ws');
+    this.stompClient = Stomp.over(socketFactory);
     this.stompClient.debug = () => {};
     const headers: { [key: string]: string } = {};
     const token = this.authService.getToken();

--- a/Frontend/src/app/services/notification.service.ts
+++ b/Frontend/src/app/services/notification.service.ts
@@ -22,8 +22,8 @@ export class NotificationService {
   }
 
   private connect(): void {
-    const socket = new SockJS('http://localhost:8080/ws');
-    this.stompClient = Stomp.over(socket);
+    const socketFactory = () => new SockJS('http://localhost:8080/ws');
+    this.stompClient = Stomp.over(socketFactory);
     (this.stompClient as any).debug = () => {};
 
     const headers: { [key: string]: string } = {};


### PR DESCRIPTION
## Summary
- create SockJS factory when connecting to STOMP so auto reconnect works
- point STOMP clients at backend WebSocket endpoint

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden fetching @kurkle/color)*
- `./mvnw -q test` *(fails: wget unable to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_689958574d5c8333b56222eade8469bc