### PR TITLE
Validate driver ID before assigning driver

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/controller/AdminOrderController.java
+++ b/Backend/backend/src/main/java/com/example/backend/controller/AdminOrderController.java
@@ -138,7 +138,10 @@ public class AdminOrderController {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<?> assignDriverToOrder(
             @PathVariable Long orderId,
-            @RequestParam Long driverId) {
+            @RequestParam(required = false) Long driverId) {
+        if (driverId == null || driverId <= 0) {
+            return ResponseEntity.badRequest().body("Invalid driver ID");
+        }
         try {
             OrderDTO updated = orderService.assignDriverToOrder(orderId, driverId);
             return ResponseEntity.ok(updated);


### PR DESCRIPTION
## Summary
- ensure AdminOrderController checks for null or non-positive driverId before assigning drivers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899611210288333a1ea5e666c089dc9