### PR TITLE
handle missing origin in cors config

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/config/SecurityConfiguration.java
+++ b/Backend/backend/src/main/java/com/example/backend/config/SecurityConfiguration.java
@@ -31,7 +31,12 @@ public class SecurityConfiguration {
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration config = new CorsConfiguration();
                     config.setAllowCredentials(true);
-                    config.setAllowedOrigins(Collections.singletonList(request.getHeader("Origin")));
+                    String origin = request.getHeader("Origin");
+                    if (origin != null && !origin.isEmpty()) {
+                        config.setAllowedOrigins(Collections.singletonList(origin));
+                    } else {
+                        config.setAllowedOriginPatterns(Collections.singletonList("*"));
+                    }
                     config.addAllowedHeader("*");
                     config.addAllowedMethod("*");
                     return config;


### PR DESCRIPTION
## Summary
- prevent 500 errors when Origin header missing by falling back to wildcard in CORS config

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899663ed27c8333beca7879c3100837