### PR TITLE
chore: add node type definitions

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -54,6 +54,7 @@
     "@types/jasmine": "~4.3.0",
     "@types/leaflet": "^1.9.17",
     "@types/mapbox__polyline": "^1.0.5",
+    "@types/node": "^20.11.0",
     "@types/sockjs-client": "^1.5.4",
     "autoprefixer": "^10.4.21",
     "jasmine-core": "~4.6.0",


### PR DESCRIPTION
## Summary
- add @types/node to devDependencies for frontend

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm install --force` *(fails: 403 Forbidden for @types/node)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e612f80883338050dc06aa7fee30