### PR TITLE
Add source map loader to webpack configuration

### DIFF
--- a/Frontend/webpack.config.js
+++ b/Frontend/webpack.config.js
@@ -15,6 +15,20 @@ module.exports = {
       tls: false,
     },
   },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        use: ['source-map-loader'],
+        exclude: [
+          /node_modules\/sockjs-client/,
+          /node_modules\/@stomp\/stompjs/,
+          /node_modules\/chart.js/
+        ]
+      }
+    ]
+  },
   plugins: [
     new webpack.ProvidePlugin({
       process: 'process/browser',


### PR DESCRIPTION
## Summary
- configure webpack to run source-map-loader on JS files while excluding known problematic modules

## Testing
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@kurkle%2fcolor)*
- `npm run build` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e60e7fe883339a587ce01a5be042