### PR TITLE
Refactor admin orders table with sorting and drawer

### DIFF
--- a/Frontend/src/app/admin/admin-orders/admin-orders.component.html
+++ b/Frontend/src/app/admin/admin-orders/admin-orders.component.html
@@ -1,99 +1,115 @@
 <div class="p-4 max-w-6xl mx-auto pb-32">
 
-    <h2 class="text-2xl font-bold mb-6 text-gray-800">📦 Orders Management</h2>
-  
-    <!-- Filter & Search -->
-    <div class="flex justify-between mb-4 items-center">
-      <label class="text-sm font-medium text-gray-700">
-        Filter by Status:
-        <select [(ngModel)]="filterStatus" (change)="fetchOrders(1)" class="ml-2 border px-3 py-1 rounded">
-          <option value="All">All</option>
-          <option value="Pending">Pending</option>
-          <option value="In Progress">In Progress</option>
-          <option value="Delivered">Delivered</option>
-        </select>
-      </label>
-      <input type="text" placeholder="Search" (input)="onSearch($any($event.target).value)" class="border px-3 py-1 rounded" />
+  <h2 class="text-2xl font-bold mb-6 text-gray-800">📦 Orders Management</h2>
+
+  <!-- Toolbar -->
+  <div class="bg-white p-4 rounded-md shadow mb-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <div class="flex items-center gap-2">
+      <label class="text-sm font-medium text-gray-700">Status:</label>
+      <select [(ngModel)]="filterStatus" (change)="fetchOrders(1)" class="border px-3 py-1 rounded">
+        <option value="All">All</option>
+        <option value="Pending">Pending</option>
+        <option value="In Progress">In Progress</option>
+        <option value="Delivered">Delivered</option>
+      </select>
     </div>
-  
-    <!-- Orders List -->
-    <app-table-skeleton *ngIf="loading"></app-table-skeleton>
-    <div *ngIf="errorMessage" class="text-red-500">{{ errorMessage }}</div>
-  
-    <div *ngFor="let order of filteredOrders()" class="bg-white rounded-lg shadow p-4 mb-4 border border-gray-200">
-      <div class="flex flex-col md:flex-row justify-between md:items-center mb-2">
-        <div class="mb-2 md:mb-0">
-          <p class="font-semibold text-lg text-gray-700">Order #{{ order.id }}</p>
-          <p class="text-sm text-gray-500">Date: {{ order.orderDate }}</p>
-          <p class="text-sm text-gray-500">User: {{ order.userEmail }}</p>
-          <p class="text-sm text-gray-500">Total: <span class="font-bold text-red-600">R{{ order.totalAmount.toFixed(2) }}</span></p>
-        </div>
-  
-        <div class="flex flex-col md:flex-row items-start md:items-center gap-2">
-          <select [(ngModel)]="order.status" (change)="updateStatus(order.id, order.status)"
-                  class="px-2 py-1 border rounded text-sm">
-            <option value="Pending">Pending</option>
-            <option value="In Progress">In Progress</option>
-            <option value="Delivered">Delivered</option>
+    <input
+      type="text"
+      placeholder="Search orders"
+      (input)="onSearch($any($event.target).value)"
+      class="border px-3 py-1 rounded w-full md:w-64" />
+  </div>
+
+  <!-- Orders Table -->
+  <app-table-skeleton *ngIf="loading"></app-table-skeleton>
+  <div *ngIf="errorMessage" class="text-red-500">{{ errorMessage }}</div>
+
+  <div class="table-container" *ngIf="!loading && !errorMessage">
+    <table class="orders-table">
+      <thead>
+        <tr>
+          <th (click)="setSort('id')">ID <span>{{ getSortIcon('id') }}</span></th>
+          <th (click)="setSort('orderDate')">Date <span>{{ getSortIcon('orderDate') }}</span></th>
+          <th (click)="setSort('userEmail')">User <span>{{ getSortIcon('userEmail') }}</span></th>
+          <th (click)="setSort('totalAmount')">Total <span>{{ getSortIcon('totalAmount') }}</span></th>
+          <th (click)="setSort('status')">Status <span>{{ getSortIcon('status') }}</span></th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let order of filteredOrders()">
+          <td>{{ order.id }}</td>
+          <td>{{ order.orderDate }}</td>
+          <td>{{ order.userEmail }}</td>
+          <td>R{{ order.totalAmount.toFixed(2) }}</td>
+          <td>
+            <select [(ngModel)]="order.status" (change)="updateStatus(order.id, order.status)"
+                    class="px-2 py-1 border rounded text-sm">
+              <option value="Pending">Pending</option>
+              <option value="In Progress">In Progress</option>
+              <option value="Delivered">Delivered</option>
+            </select>
+          </td>
+          <td>
+            <button (click)="openDrawer(order)"
+                    class="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm">View</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Pagination -->
+  <app-pagination [currentPage]="currentPage" [totalPages]="totalPages" (pageChange)="onPageChange($event)"></app-pagination>
+
+  <!-- Drawer -->
+  <div *ngIf="selectedOrder" class="drawer">
+    <div class="drawer-overlay" (click)="closeDrawer()"></div>
+    <div class="drawer-panel">
+      <button (click)="closeDrawer()" class="absolute top-3 right-4 text-gray-500 hover:text-black text-xl">&times;</button>
+      <h3 class="text-xl font-semibold text-gray-800 mb-4">🧾 Order Details #{{ selectedOrder.id }}</h3>
+
+      <p><strong>Status:</strong> <span [ngClass]="getStatusColor(selectedOrder.status)">{{ selectedOrder.status }}</span></p>
+      <p><strong>User Email:</strong> {{ selectedOrder.userEmail }}</p>
+      <p><strong>Payment ID:</strong> {{ selectedOrder.paymentId }}</p>
+      <p><strong>Delivery Address:</strong> {{ selectedOrder.deliveryAddress }}</p>
+
+      <div class="mt-4">
+        <h4 class="font-bold text-gray-700 mb-2">Ordered Items:</h4>
+        <ul class="divide-y divide-gray-200">
+          <li *ngFor="let item of selectedOrder.items" class="py-2">
+            <div class="flex justify-between">
+              <span>{{ item.name }} <span class="text-sm text-gray-500">({{ item.size }})</span></span>
+              <span class="font-medium">Qty: {{ item.quantity }}</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mt-4">
+        <h4 class="font-bold text-gray-700 mb-2">Assign Driver:</h4>
+
+        <div class="flex flex-col md:flex-row items-center gap-2">
+          <select [(ngModel)]="selectedDriverId" class="border px-3 py-2 rounded w-full md:w-auto">
+            <option [ngValue]="null">-- Select a Driver --</option>
+            <option *ngFor="let driver of availableDrivers" [ngValue]="driver.id">
+              {{ driver.email }}
+            </option>
           </select>
-          <button (click)="openModal(order)"
-                  class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition text-sm">
-            View
+
+          <button
+            (click)="assignDriver()"
+            [disabled]="!selectedDriverId || assigning"
+            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center justify-center">
+            <ng-container *ngIf="!assigning; else loadingTpl">Assign</ng-container>
+            <ng-template #loadingTpl>
+              <app-button-spinner></app-button-spinner>
+            </ng-template>
           </button>
         </div>
       </div>
-    </div>
-  
-    <!-- Pagination -->
-    <app-pagination [currentPage]="currentPage" [totalPages]="totalPages" (pageChange)="onPageChange($event)"></app-pagination>
-  
-    <!-- Modal -->
-    <div *ngIf="selectedOrder" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div class="bg-white w-full max-w-2xl mx-4 p-6 rounded-lg shadow-lg relative">
-        <button (click)="closeModal()" class="absolute top-3 right-4 text-gray-500 hover:text-black text-xl">&times;</button>
-        <h3 class="text-xl font-semibold text-gray-800 mb-4">🧾 Order Details #{{ selectedOrder.id }}</h3>
-  
-        <p><strong>Status:</strong> <span [ngClass]="getStatusColor(selectedOrder.status)">{{ selectedOrder.status }}</span></p>
-        <p><strong>User Email:</strong> {{ selectedOrder.userEmail }}</p>
-        <p><strong>Payment ID:</strong> {{ selectedOrder.paymentId }}</p>
-        <p><strong>Delivery Address:</strong> {{ selectedOrder.deliveryAddress }}</p>
-  
-        <div class="mt-4">
-          <h4 class="font-bold text-gray-700 mb-2">Ordered Items:</h4>
-          <ul class="divide-y divide-gray-200">
-            <li *ngFor="let item of selectedOrder.items" class="py-2">
-              <div class="flex justify-between">
-                <span>{{ item.name }} <span class="text-sm text-gray-500">({{ item.size }})</span></span>
-                <span class="font-medium">Qty: {{ item.quantity }}</span>
-              </div>
-            </li>
-          </ul>
-        </div>
 
-        <div class="mt-4">
-          <h4 class="font-bold text-gray-700 mb-2">Assign Driver:</h4>
-        
-          <div class="flex flex-col md:flex-row items-center gap-2">
-            <select [(ngModel)]="selectedDriverId" class="border px-3 py-2 rounded w-full md:w-auto">
-              <option [ngValue]="null">-- Select a Driver --</option>
-              <option *ngFor="let driver of availableDrivers" [ngValue]="driver.id">
-                {{ driver.email }}
-              </option>
-            </select>
-        
-            <button
-              (click)="assignDriver()"
-              [disabled]="!selectedDriverId || assigning"
-              class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center justify-center">
-              <ng-container *ngIf="!assigning; else loadingTpl">Assign</ng-container>
-              <ng-template #loadingTpl>
-                <app-button-spinner></app-button-spinner>
-              </ng-template>
-            </button>
-          </div>
-        </div>
-        
-      </div>
     </div>
   </div>
-  
+
+</div>

--- a/Frontend/src/app/admin/admin-orders/admin-orders.component.scss
+++ b/Frontend/src/app/admin/admin-orders/admin-orders.component.scss
@@ -1,0 +1,41 @@
+
+.table-container {
+  overflow-x: auto;
+}
+
+.orders-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    @apply px-4 py-2 text-left text-sm;
+  }
+
+  th {
+    @apply bg-gray-100 font-semibold cursor-pointer select-none;
+  }
+
+  tbody tr {
+    @apply border-b hover:bg-gray-50;
+  }
+}
+
+@media (max-width: 640px) {
+  .orders-table th,
+  .orders-table td {
+    @apply px-2 py-1;
+  }
+}
+
+.drawer {
+  @apply fixed inset-0 flex justify-end z-50;
+}
+
+.drawer-overlay {
+  @apply absolute inset-0 bg-black bg-opacity-40;
+}
+
+.drawer-panel {
+  @apply relative bg-white w-full sm:w-96 h-full shadow-lg p-6 overflow-y-auto;
+}

--- a/Frontend/src/app/admin/admin-orders/admin-orders.component.ts
+++ b/Frontend/src/app/admin/admin-orders/admin-orders.component.ts
@@ -35,6 +35,9 @@ export class AdminOrdersComponent implements OnInit, OnDestroy {
   selectedDriverId: number | null = null;
   assigning = false;
 
+  sortColumn: keyof Order = 'id';
+  sortDirection: 'asc' | 'desc' = 'asc';
+
   currentPage = 1;
   pageSize = 5;
   totalPages = 0;
@@ -86,7 +89,7 @@ export class AdminOrdersComponent implements OnInit, OnDestroy {
     this.orders = this.orders.map(o => (o.id === orderId ? { ...o, status: newStatus } : o));
   }
 
-  openModal(order: Order): void {
+  openDrawer(order: Order): void {
     this.selectedOrder = order;
     this.adminSerivce.getAvailableDrivers().subscribe({
       next: drivers => (this.availableDrivers = drivers),
@@ -94,7 +97,7 @@ export class AdminOrdersComponent implements OnInit, OnDestroy {
     });
   }
 
-  closeModal(): void {
+  closeDrawer(): void {
     this.selectedOrder = null;
   }
 
@@ -115,9 +118,36 @@ export class AdminOrdersComponent implements OnInit, OnDestroy {
     });
   }
 
+  setSort(column: keyof Order): void {
+    if (this.sortColumn === column) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortColumn = column;
+      this.sortDirection = 'asc';
+    }
+  }
+
+  getSortIcon(column: keyof Order): string {
+    if (this.sortColumn !== column) return '';
+    return this.sortDirection === 'asc' ? '▲' : '▼';
+  }
+
   filteredOrders(): Order[] {
-    if (this.filterStatus === 'All') return this.orders;
-    return this.orders.filter(o => o.status === this.filterStatus);
+    const list = this.filterStatus === 'All'
+      ? [...this.orders]
+      : this.orders.filter(o => o.status === this.filterStatus);
+    return list.sort((a, b) => {
+      const col = this.sortColumn;
+      const valA = (a as any)[col];
+      const valB = (b as any)[col];
+      if (valA < valB) {
+        return this.sortDirection === 'asc' ? -1 : 1;
+      }
+      if (valA > valB) {
+        return this.sortDirection === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
   }
 
   getStatusColor(status: string): string {


### PR DESCRIPTION
## Summary
- Replace admin orders card list with sortable, responsive table
- Combine status filter and debounced search into a toolbar
- Move driver assignment into side drawer with order details
- Add modern table and drawer styles

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a119cb65ac83338a0f513552bee6af