### PR TITLE
Add cross-role redirects in driver and admin guards

### DIFF
--- a/Frontend/src/app/guards/admin.guard.ts
+++ b/Frontend/src/app/guards/admin.guard.ts
@@ -10,13 +10,24 @@ export class AdminGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
   canActivate(): boolean {
+    if (!this.authService.isLoggedIn()) {
+      this.router.navigate(['/login']);
+      return false;
+    }
+
     const role = this.authService.getUserRole();
     console.log("🛡️ AdminGuard checked role:", role); // should show ROLE_ADMIN
     if (role === 'ROLE_ADMIN') {
       return true;
-    } else {
+    } else if (role === 'ROLE_MANAGER') {
+      this.router.navigate(['/manager/dashboard']);
+    } else if (role === 'ROLE_DRIVER') {
+      this.router.navigate(['/driver/dashboard']);
+    } else if (role === 'ROLE_USER') {
       this.router.navigate(['/']);
-      return false;
+    } else {
+      this.router.navigate(['/login']);
     }
+    return false;
   }
 }

--- a/Frontend/src/app/guards/driver.guard.ts
+++ b/Frontend/src/app/guards/driver.guard.ts
@@ -7,10 +7,23 @@ export class DriverGuard implements CanActivate {
   constructor(private auth: AuthService, private router: Router) {}
 
   canActivate(): boolean {
-    const role = this.auth.getUserRole();
-    if (role === 'ROLE_DRIVER') return true;
+    if (!this.auth.isLoggedIn()) {
+      this.router.navigate(['/login']);
+      return false;
+    }
 
-    this.router.navigate(['/login']);
+    const role = this.auth.getUserRole();
+    if (role === 'ROLE_DRIVER') {
+      return true;
+    } else if (role === 'ROLE_ADMIN') {
+      this.router.navigate(['/admin/dashboard']);
+    } else if (role === 'ROLE_MANAGER') {
+      this.router.navigate(['/manager/dashboard']);
+    } else if (role === 'ROLE_USER') {
+      this.router.navigate(['/']);
+    } else {
+      this.router.navigate(['/login']);
+    }
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Check login state and redirect logged-in users to their own dashboards in `DriverGuard`
- Apply the same cross-role handling to `AdminGuard`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68a13149b224833389713566a511f428