### PR TITLE
feat: decode user role with jwt

### DIFF
--- a/Frontend/src/app/services/auth.service.ts
+++ b/Frontend/src/app/services/auth.service.ts
@@ -82,9 +82,9 @@ export class AuthService {
   getUserRole(): string | null {
     const token = this.getToken();
     if (!token) return null;
-  
+
     try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
+      const payload: any = jwtDecode(token);
       console.log("Decoded Role:", payload.role); // ✅ Debug log
       return payload.role || null;
     } catch (error) {


### PR DESCRIPTION
## Summary
- use `jwtDecode` in `AuthService.getUserRole` to extract `payload.role`
- keep guards comparing against `ROLE_*` constants

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68a1314c8d6c8333b6e25bd861b3e6dd