### PR TITLE
Fix admin route precedence

### DIFF
--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -64,8 +64,8 @@ import { AdminLayoutComponent } from './admin/admin-layout/admin-layout.componen
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule,
     AdminRoutingModule,
+    AppRoutingModule,
     HttpClientModule,
     FormsModule,
     ReactiveFormsModule,


### PR DESCRIPTION
## Summary
- Register admin routes before app routes so AdminGuard handles `/admin` navigation

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: bundle initial exceeded maximum budget)*

------
https://chatgpt.com/codex/tasks/task_e_68a1314c9db88333a09b8d6016ee3bf8