### PR TITLE
Remove sidebar from admin layout for full-width content

### DIFF
--- a/Frontend/src/app/admin/admin-layout/admin-layout.component.html
+++ b/Frontend/src/app/admin/admin-layout/admin-layout.component.html
@@ -1,25 +1,5 @@
-<div class="flex min-h-screen bg-gray-100">
-  <aside class="w-64 bg-gray-800 text-white flex flex-col">
-    <div class="p-4 text-2xl font-bold">Admin</div>
-    <nav class="flex-1 p-2 space-y-1">
-      <a routerLink="dashboard" routerLinkActive="bg-gray-900" [routerLinkActiveOptions]="{ exact: true }" class="flex items-center p-2 rounded hover:bg-gray-700">
-        <span class="mr-3">🏠</span><span>Dashboard</span>
-      </a>
-      <a routerLink="orders" routerLinkActive="bg-gray-900" class="flex items-center p-2 rounded hover:bg-gray-700">
-        <span class="mr-3">🧾</span><span>Orders</span>
-      </a>
-      <a routerLink="menu" routerLinkActive="bg-gray-900" class="flex items-center p-2 rounded hover:bg-gray-700">
-        <span class="mr-3">🍔</span><span>Menu</span>
-      </a>
-      <a routerLink="drivers" routerLinkActive="bg-gray-900" class="flex items-center p-2 rounded hover:bg-gray-700">
-        <span class="mr-3">🚚</span><span>Drivers</span>
-      </a>
-      <a routerLink="inventory" routerLinkActive="bg-gray-900" class="flex items-center p-2 rounded hover:bg-gray-700">
-        <span class="mr-3">📦</span><span>Inventory</span>
-      </a>
-    </nav>
-  </aside>
-  <main class="flex-1 p-6 overflow-y-auto">
+<div class="min-h-screen bg-gray-100">
+  <main class="w-full p-6 overflow-y-auto">
     <router-outlet></router-outlet>
   </main>
 </div>


### PR DESCRIPTION
## Summary
- simplify admin layout by removing sidebar
- ensure main content spans full width of the screen

## Testing
- `npm run build -- --progress=false` *(fails: bundle initial exceeded maximum budget)*
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68a139f53e288333920991c4a3da0353