### PR TITLE
fix(frontend): correct custom webpack config path

### DIFF
--- a/Frontend/angular.json
+++ b/Frontend/angular.json
@@ -39,7 +39,7 @@
             ],
             "scripts": [],
             "customWebpackConfig": {
-              "path": "./webpack.config.js"
+              "path": "./webpack.custom.js"
             }
           },
           "configurations": {


### PR DESCRIPTION
## Summary
- fix angular build configuration to use webpack.custom.js

## Testing
- `ng serve` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a227d286288333846ffbc6aaf455ea