### PR TITLE
chore: expand admin dashboard module

### DIFF
--- a/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
@@ -1,12 +1,37 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { AdminDashboardComponent } from './admin-dashboard.component';
 import { AdminNotificationsComponent } from '../admin-notifications/admin-notifications.component';
+import { AdminOrdersComponent } from '../admin-orders/admin-orders.component';
+import { AdminMenuComponent } from '../admin-menu/admin-menu.component';
+import { AdminDriversComponent } from '../admin-drivers/admin-drivers.component';
+import { AdminDriverMapComponent } from '../admin-drivers/admin-driver-map.component';
+import { AdminFooterComponent } from '../admin-footer/admin-footer.component';
+import { AdminDiagnosticsComponent } from '../admin-diagnostics/admin-diagnostics.component';
+import { InventoryManagementComponent } from '../inventory-management/inventory-management.component';
+import { DriverDashboardComponent } from '../../driver/driver-dashboard/driver-dashboard.component';
+import { DriverMapComponent } from '../../driver/driver-map/driver-map.component';
+import { ManagerDashboardComponent } from '../../manager/manager-dashboard/manager-dashboard.component';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
-  declarations: [AdminDashboardComponent, AdminNotificationsComponent],
-  imports: [CommonModule, FormsModule],
-  exports: [AdminDashboardComponent]
+  declarations: [
+    AdminDashboardComponent,
+    AdminNotificationsComponent,
+    AdminOrdersComponent,
+    AdminMenuComponent,
+    AdminDriversComponent,
+    AdminDriverMapComponent,
+    AdminFooterComponent,
+    AdminDiagnosticsComponent,
+    InventoryManagementComponent,
+    DriverDashboardComponent,
+    DriverMapComponent,
+    ManagerDashboardComponent,
+  ],
+  imports: [CommonModule, FormsModule, RouterModule, SharedModule],
+  exports: [AdminDashboardComponent, AdminFooterComponent]
 })
 export class AdminDashboardModule {}


### PR DESCRIPTION
## Summary
- register admin, driver, and manager components within AdminDashboardModule
- expose AdminDashboardComponent and AdminFooterComponent

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b474c5b0a88333a4194b475be941f3