### PR TITLE
refactor: delegate admin and manager routing

### DIFF
--- a/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
@@ -3,10 +3,11 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { AdminDashboardComponent } from './admin-dashboard.component';
 import { AdminNotificationsComponent } from '../admin-notifications/admin-notifications.component';
+import { AdminRoutingModule } from '../admin-routing.module';
 
 @NgModule({
   declarations: [AdminDashboardComponent, AdminNotificationsComponent],
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, AdminRoutingModule],
   exports: [AdminDashboardComponent]
 })
 export class AdminDashboardModule {}

--- a/Frontend/src/app/app-routing.module.ts
+++ b/Frontend/src/app/app-routing.module.ts
@@ -8,20 +8,9 @@ import { ProductComponent } from './pages/product/product.component';
 import { CheckoutComponent } from './pages/checkout/checkout.component';
 import { ThankYouComponent } from './components/thank-you/thank-you.component';
 import { HistoryordersComponent } from './pages/historyorders/historyorders.component';
-
-// 🛠️ Admin
-import { AdminDashboardComponent } from './admin/admin-dashboard/admin-dashboard.component';
-import { AdminOrdersComponent } from './admin/admin-orders/admin-orders.component';
-import { AdminMenuComponent } from './admin/admin-menu/admin-menu.component';
-import { AdminDriversComponent } from './admin/admin-drivers/admin-drivers.component';
-import { InventoryManagementComponent } from './admin/inventory-management/inventory-management.component';
-import { AdminGuard } from './guards/admin.guard';
 import { UserGuard } from './guards/user.guard';
 import { DriverDashboardComponent } from './driver/driver-dashboard/driver-dashboard.component';
 import { DriverGuard } from './guards/driver.guard';
-import { AdminDiagnosticsComponent } from './admin/admin-diagnostics/admin-diagnostics.component';
-import { ManagerDashboardComponent } from './manager/manager-dashboard/manager-dashboard.component';
-import { ManagerGuard } from './guards/manager.guard';
 
 const routes: Routes = [
   // 🌐 User Routes
@@ -34,31 +23,6 @@ const routes: Routes = [
 
   { path: 'login', component: LoginComponent },
   { path: 'register', component: RegisterComponent },
-
-  // 🧭 Manager Routes
-  {
-    path: 'manager',
-    canActivate: [ManagerGuard],
-    children: [
-      { path: 'dashboard', component: AdminDashboardComponent },
-      { path: 'orders', component: AdminOrdersComponent },
-      { path: 'menu', component: AdminMenuComponent },
-      { path: 'drivers', component: AdminDriversComponent },
-      { path: 'diagnostics', component: AdminDiagnosticsComponent },
-      { path: 'inventory', component: InventoryManagementComponent },
-      { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
-    ]
-  },
-
-  // 🧭 Manager Routes
-  {
-    path: 'manager',
-    canActivate: [ManagerGuard],
-    children: [
-      { path: 'dashboard', component: ManagerDashboardComponent },
-      { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
-    ]
-  },
 
   // 🚚 Driver Route
   {

--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -32,7 +32,7 @@ import { InventoryManagementComponent } from './admin/inventory-management/inven
 import { LoadersModule } from './shared/loaders/loaders.module';
 import { LoaderInterceptor } from './shared/loaders/loader.interceptor';
 import { PaginationComponent } from './components/pagination/pagination.component';
-import { ManagerDashboardComponent } from './manager/manager-dashboard/manager-dashboard.component';
+import { ManagerModule } from './manager/manager.module';
 
 
 @NgModule({
@@ -59,17 +59,16 @@ import { ManagerDashboardComponent } from './manager/manager-dashboard/manager-d
     DriverMapComponent,
     InventoryManagementComponent,
     PaginationComponent,
-    ManagerDashboardComponent,
   ],
   imports: [
     BrowserModule,
-    AdminRoutingModule,
     AppRoutingModule,
     HttpClientModule,
     FormsModule,
     ReactiveFormsModule,
     BrowserAnimationsModule,
     AdminDashboardModule,
+    ManagerModule,
     LoadersModule,
     ToastrModule.forRoot({
       positionClass: 'toast-bottom-right',

--- a/Frontend/src/app/manager/manager-routing.module.ts
+++ b/Frontend/src/app/manager/manager-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ManagerDashboardComponent } from './manager-dashboard/manager-dashboard.component';
+import { ManagerGuard } from '../guards/manager.guard';
+
+const routes: Routes = [
+  {
+    path: 'manager',
+    canActivate: [ManagerGuard],
+    children: [
+      { path: 'dashboard', component: ManagerDashboardComponent },
+      { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ManagerRoutingModule {}

--- a/Frontend/src/app/manager/manager.module.ts
+++ b/Frontend/src/app/manager/manager.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ManagerDashboardComponent } from './manager-dashboard/manager-dashboard.component';
+import { ManagerRoutingModule } from './manager-routing.module';
+
+@NgModule({
+  declarations: [ManagerDashboardComponent],
+  imports: [CommonModule, ManagerRoutingModule],
+  exports: [ManagerDashboardComponent]
+})
+export class ManagerModule {}


### PR DESCRIPTION
## Summary
- isolate global routing by removing admin and manager paths from `AppRoutingModule`
- wire admin routes through `AdminDashboardModule` and introduce manager feature routing
- register `ManagerModule` in the root module

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b474cbbbcc83339be5fcbb10aa9959