### PR TITLE
refactor: clean app module imports

### DIFF
--- a/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/Frontend/src/app/admin/admin-dashboard/admin-dashboard.module.ts
@@ -1,8 +1,8 @@
 import { NgModule } from '@angular/core';
-import { SharedModule } from '../../shared/shared.module';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+
 import { AdminDashboardComponent } from './admin-dashboard.component';
 import { AdminNotificationsComponent } from '../admin-notifications/admin-notifications.component';
 import { AdminOrdersComponent } from '../admin-orders/admin-orders.component';
@@ -15,7 +15,9 @@ import { InventoryManagementComponent } from '../inventory-management/inventory-
 import { DriverDashboardComponent } from '../../driver/driver-dashboard/driver-dashboard.component';
 import { DriverMapComponent } from '../../driver/driver-map/driver-map.component';
 import { ManagerDashboardComponent } from '../../manager/manager-dashboard/manager-dashboard.component';
+import { AdminLayoutComponent } from '../admin-layout/admin-layout.component';
 import { SharedModule } from '../../shared/shared.module';
+import { AdminRoutingModule } from '../admin-routing.module';
 
 @NgModule({
   declarations: [
@@ -31,15 +33,10 @@ import { SharedModule } from '../../shared/shared.module';
     DriverDashboardComponent,
     DriverMapComponent,
     ManagerDashboardComponent,
+    AdminLayoutComponent,
   ],
-  imports: [CommonModule, FormsModule, RouterModule, SharedModule],
-  exports: [AdminDashboardComponent, AdminFooterComponent]
-import { AdminRoutingModule } from '../admin-routing.module';
-
-@NgModule({
-  declarations: [AdminDashboardComponent, AdminNotificationsComponent],
-  imports: [SharedModule],
-  imports: [CommonModule, FormsModule, AdminRoutingModule],
-  exports: [AdminDashboardComponent]
+  imports: [CommonModule, FormsModule, RouterModule, SharedModule, AdminRoutingModule],
+  exports: [AdminDashboardComponent, AdminFooterComponent],
 })
 export class AdminDashboardModule {}
+

--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -1,9 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
-import { AdminRoutingModule } from './admin/admin-routing.module';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { SharedModule } from './shared/shared.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { ToastrModule } from 'ngx-toastr';
@@ -24,14 +22,8 @@ import { AdminDashboardModule } from './admin/admin-dashboard/admin-dashboard.mo
 import { AuthInterceptor } from './authInterceptor/auth.interceptor';
 import { LoaderInterceptor } from './shared/loaders/loader.interceptor';
 import { SharedModule } from './shared/shared.module';
-import { DriverMapComponent } from './driver/driver-map/driver-map.component';
-import { AdminFooterComponent } from './admin/admin-footer/admin-footer.component';
-import { AdminDiagnosticsComponent } from './admin/admin-diagnostics/admin-diagnostics.component';
-import { InventoryManagementComponent } from './admin/inventory-management/inventory-management.component';
-import { LoaderInterceptor } from './shared/loaders/loader.interceptor';
-import { ManagerDashboardComponent } from './manager/manager-dashboard/manager-dashboard.component';
-import { PaginationComponent } from './components/pagination/pagination.component';
 import { ManagerModule } from './manager/manager.module';
+import { LoadersModule } from './shared/loaders/loaders.module';
 
 
 @NgModule({
@@ -52,20 +44,6 @@ import { ManagerModule } from './manager/manager.module';
   imports: [
     BrowserModule,
     RouterModule,
-    AdminOrdersComponent,
-    AdminMenuComponent,
-    AdminDriversComponent,
-    AdminDriverMapComponent,
-    AdminFooterComponent,
-    AdminDiagnosticsComponent,
-    DriverDashboardComponent,
-    DriverMapComponent,
-    InventoryManagementComponent,
-    ManagerDashboardComponent,
-    PaginationComponent,
-  ],
-  imports: [
-    BrowserModule,
     AppRoutingModule,
     HttpClientModule,
     BrowserAnimationsModule,


### PR DESCRIPTION
## Summary
- remove duplicate SharedModule and LoaderInterceptor imports
- consolidate AppModule imports to include required modules only
- declare admin components in AdminDashboardModule

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular-devkit%2fbuild-angular)*

------
https://chatgpt.com/codex/tasks/task_e_68b4798ee1348333b454ae198628fa18