### PR TITLE
refactor: move standalone components to imports

### DIFF
--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -21,12 +21,6 @@ import { HistoryordersComponent } from './pages/historyorders/historyorders.comp
 import { AdminDashboardModule } from './admin/admin-dashboard/admin-dashboard.module';
 import { AuthInterceptor } from './authInterceptor/auth.interceptor';
 import { LoaderInterceptor } from './shared/loaders/loader.interceptor';
-import { DriverMapComponent } from './driver/driver-map/driver-map.component';
-import { AdminFooterComponent } from './admin/admin-footer/admin-footer.component';
-import { AdminDiagnosticsComponent } from './admin/admin-diagnostics/admin-diagnostics.component';
-import { InventoryManagementComponent } from './admin/inventory-management/inventory-management.component';
-import { ManagerDashboardComponent } from './manager/manager-dashboard/manager-dashboard.component';
-import { PaginationComponent } from './components/pagination/pagination.component';
 import { SharedModule } from './shared/shared.module';
 import { ManagerModule } from './manager/manager.module';
 import { LoadersModule } from './shared/loaders/loaders.module';
@@ -34,7 +28,18 @@ import { LoadersModule } from './shared/loaders/loaders.module';
 
 @NgModule({
   declarations: [
-    AppComponent,
+    AppComponent
+  ],
+  imports: [
+    BrowserModule,
+    RouterModule,
+    AppRoutingModule,
+    HttpClientModule,
+    BrowserAnimationsModule,
+    AdminDashboardModule,
+    SharedModule,
+    ManagerModule,
+    LoadersModule,
     HomeComponent,
     CartComponent,
     OrdersComponent,
@@ -46,16 +51,6 @@ import { LoadersModule } from './shared/loaders/loaders.module';
     CheckoutComponent,
     ThankYouComponent,
     HistoryordersComponent,
-  ],
-  imports: [
-    BrowserModule,
-    RouterModule,
-    AppRoutingModule,
-    HttpClientModule,
-    BrowserAnimationsModule,
-    AdminDashboardModule,
-    SharedModule,
-    ManagerModule,
     ToastrModule.forRoot({
       positionClass: 'toast-bottom-right',
       timeOut: 4000,


### PR DESCRIPTION
## Summary
- import standalone components in `AppModule` and remove them from `declarations`
- keep only `AppComponent` declared in `AppModule`
- include `LoadersModule` alongside feature modules

## Testing
- `npm run build` *(fails: sh: 1: ng: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b48a7b74708333afd2f620f159804b