### PR TITLE
fix: make GET /api/reviews public for guest browsing

### DIFF
--- a/Backend/backend/src/main/java/com/example/backend/config/SecurityConfiguration.java
+++ b/Backend/backend/src/main/java/com/example/backend/config/SecurityConfiguration.java
@@ -57,6 +57,7 @@ public class SecurityConfiguration {
                                 "/api/tenants/{slug}",
                                 "/api/map/route",
                                 "/api/orders/place",
+                                "/api/reviews",
                                 "/store/**",
                                 "/images/**",
                                 "/uploads/**"


### PR DESCRIPTION
## Summary
- Added `/api/reviews` to the public `permitAll` routes in SecurityConfiguration
- Without this, guests browsing the home/menu page got a 403 and the reviews section never loaded

## Root Cause
The reviews section on the home page uses `*ngIf="reviews.length > 0"` — it was always hidden because the API call failed silently with 403 for unauthenticated users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)